### PR TITLE
Patch match up component on Landing

### DIFF
--- a/src/components/LandingPage/TeamLandingPageComponents.tsx
+++ b/src/components/LandingPage/TeamLandingPageComponents.tsx
@@ -207,7 +207,7 @@ export const TeamMatchUp = ({ team, week, league, ts, matchUp,
       gameScore = `${matchUp[0].HomeTeamScore} - ${matchUp[0].AwayTeamScore}`;
     } else {
       resultColor = matchUp[0].AwayTeamWin ? "text-green-500" : "text-red-500";
-      gameScore = `${matchUp[0].AwayTeamScore} - ${matchUp[0].HomeTeamScore}`;
+      gameScore = `${matchUp[0].HomeTeamScore} - ${matchUp[0].AwayTeamScore}`;
     }
   }
 


### PR DESCRIPTION
Was showing score incorrectly for an away win, now should show score in green for home or away win or red for home or away loss.

![image](https://github.com/user-attachments/assets/fe45cb51-ee1e-49c6-bd17-9c0f8c6dca27)
