### PR TITLE
Fix Landing Page Match Up component, and adjust spacing

### DIFF
--- a/src/components/Common/Modals.tsx
+++ b/src/components/Common/Modals.tsx
@@ -398,7 +398,7 @@ export const PHLPlayerInfoModalBody: FC<PHLPlayerInfoModalBodyProps> = ({
           {chlTeam.Abbreviation}
         </Text>
       </div>
-      <div className="flex flex-col">
+      <div className="flex flex-col items-center">
         <Text variant="body" classes="mb-1 whitespace-nowrap font-semibold">
           Drafted
         </Text>
@@ -411,7 +411,7 @@ export const PHLPlayerInfoModalBody: FC<PHLPlayerInfoModalBodyProps> = ({
             <Text variant="small" classes="whitespace-nowrap">
               Round {player.DraftedRound} - Pick {player.DraftedPick}
             </Text>
-            <Text variant="xs" classes="whitespace-nowrap">
+            <Text variant="xs" classes="whitespace-nowrap text-small">
               by {player.DraftedTeam}
             </Text>
           </>
@@ -829,7 +829,7 @@ export const NFLPlayerInfoModalBody: FC<NFLPlayerInfoModalBodyProps> = ({
           {cfbTeam?.TeamAbbr}
         </Text>
       </div>
-      <div className="flex flex-col">
+      <div className="flex flex-col items-center">
         <Text variant="body" classes="mb-1 whitespace-nowrap font-semibold">
           Drafted
         </Text>
@@ -842,7 +842,7 @@ export const NFLPlayerInfoModalBody: FC<NFLPlayerInfoModalBodyProps> = ({
             <Text variant="small" classes="whitespace-nowrap">
               Round {player.DraftedRound} - Pick {player.DraftedPick}
             </Text>
-            <Text variant="xs" classes="whitespace-nowrap">
+            <Text variant="xs" classes="whitespace-nowrap text-small">
               by {player.DraftedTeam}
             </Text>
           </>

--- a/src/components/LandingPage/TeamLandingPageComponents.tsx
+++ b/src/components/LandingPage/TeamLandingPageComponents.tsx
@@ -106,7 +106,7 @@ export const GamesBar = ({ games, league, team, ts,
 
   return (
     <div className="flex pb-1">
-      <div className="flex w-[90vw] md:w-[72em] 3xl:w-[70vw] max-w-[1400px] justify-center">
+      <div className="flex w-[90vw] sm:w-full max-w-[1400px] justify-center">
         <div className="relative flex items-center w-[92vw] md:w-[72.6em] 3xl:w-full pb-1">
           <button
             onClick={scrollLeft}
@@ -204,21 +204,29 @@ export const TeamMatchUp = ({
   borderColor,
   isLoadingTwo,
 }: TeamMatchUpProps) => {
+  
   const textColorClass = getTextColorBasedOnBg(backgroundColor);
   const revealResult = matchUp.length > 0 && RevealFBResults(matchUp[0], ts, league);
-
   let resultColor = "";
   let gameScore = "";
   let gameLocation = "";
+  let coaches: string[] = [];
+  let isHomeGame = false;
 
-  if (revealResult) {
-    const isHomeGame = matchUp[0].HomeTeamID === team.ID;
-    const userTeamScore = isHomeGame ? matchUp[0].HomeTeamScore : matchUp[0].AwayTeamScore;
-    const opponentScore = isHomeGame ? matchUp[0].AwayTeamScore : matchUp[0].HomeTeamScore;
-
-    resultColor = userTeamScore > opponentScore ? "text-green-500" : "text-red-500";
-    gameScore = `${userTeamScore} - ${opponentScore}`;
+  if (matchUp?.length > 0){
+    const userGame = matchUp[0];
+    isHomeGame = matchUp[0].HomeTeamID === team.ID;
+    coaches = isHomeGame
+    ? [userGame.HomeTeamCoach, userGame.AwayTeamCoach]
+    : [userGame.AwayTeamCoach, userGame.HomeTeamCoach];
     gameLocation = isHomeGame ? "VS" : "AT";
+
+    if (revealResult) {
+      const userTeamScore = isHomeGame ? matchUp[0].HomeTeamScore : matchUp[0].AwayTeamScore;
+      const opponentScore = isHomeGame ? matchUp[0].AwayTeamScore : matchUp[0].HomeTeamScore;
+      resultColor = userTeamScore > opponentScore ? "text-green-500" : "text-red-500";
+      gameScore = `${userTeamScore} - ${opponentScore}`;
+    }
   }
 
   return (
@@ -237,7 +245,7 @@ export const TeamMatchUp = ({
         <>
           <div className="flex justify-center">
             <div className="flex-col pb-2">
-              <Logo variant="large" containerClass="max-w-24" url={homeLogo} />
+              <Logo variant="large" containerClass="max-w-24 w-24" url={homeLogo} />
               <Text
                 variant="small"
                 classes={`${textColorClass} font-semibold`}
@@ -246,7 +254,7 @@ export const TeamMatchUp = ({
                 {homeLabel}
               </Text>
               <Text variant="xs" classes="opacity-70">
-                {`HC ${matchUp[0].HomeTeamCoach}`}
+                {`HC ${coaches[0]}`}
               </Text>
             </div>
             <Text
@@ -265,7 +273,7 @@ export const TeamMatchUp = ({
                 {awayLabel}
               </Text>
               <Text variant="xs" classes="opacity-70">
-                {`HC ${matchUp[0].AwayTeamCoach}`}
+                {`HC ${coaches[1]}`}
               </Text>
             </div>
           </div>

--- a/src/components/LandingPage/TeamLandingPageHelper.tsx
+++ b/src/components/LandingPage/TeamLandingPageHelper.tsx
@@ -64,6 +64,7 @@ export const getLandingCFBData = (
       .reverse();
 
     // Team Match-Up
+    const teamAbbrMap = new Map(allCollegeTeams.map((team) => [team.ID, team.TeamAbbr]));
     let foundMatch: CollegeGame[] | null = null;
     let gameWeek = currentWeek;
 
@@ -104,17 +105,16 @@ export const getLandingCFBData = (
       );
 
       homeLabel = isUserTeamHome
-        ? teamMatchUp[0].HomeTeam
-        : teamMatchUp[0].AwayTeam;
+      ? teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown"
+      : teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown";
       awayLabel = isUserTeamHome
-        ? teamMatchUp[0].AwayTeam
-        : teamMatchUp[0].HomeTeam;
+      ? teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown"
+      : teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown";
 
       gameLocation = isUserTeamHome ? "VS" : "AT";
     }
 
     // Team Schedule
-    const teamAbbrMap = new Map(allCollegeTeams.map((team) => [team.ID, team.TeamAbbr]));
     const teamSchedule = allCollegeGames
       .filter((game) => game.HomeTeamID === team.ID || 
                         game.AwayTeamID === team.ID)
@@ -184,6 +184,7 @@ export const getLandingNFLData = (
         .reverse();
       
       // Team Match-Up
+      const teamAbbrMap = new Map(allProTeams.map((team) => [team.ID, team.TeamAbbr]));
       let foundMatch: NFLGame[] | null = null;
       let gameWeek = currentWeek;
 
@@ -224,17 +225,16 @@ export const getLandingNFLData = (
         );
 
         homeLabel = isUserTeamHome
-          ? teamMatchUp[0].HomeTeam
-          : teamMatchUp[0].AwayTeam;
+        ? teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown"
+        : teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown";
         awayLabel = isUserTeamHome
-          ? teamMatchUp[0].AwayTeam
-          : teamMatchUp[0].HomeTeam;
+        ? teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown"
+        : teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown";
 
         gameLocation = isUserTeamHome ? "VS" : "AT";
       }
 
       // Team Schedule
-      const teamAbbrMap = new Map(allProTeams.map((team) => [team.ID, team.TeamAbbr]));
       const teamSchedule = allProGames
         .filter((game) => game.HomeTeamID === team.ID || 
                           game.AwayTeamID === team.ID)
@@ -304,6 +304,7 @@ export const getLandingNFLData = (
         .reverse();
   
       // Team Match-Up
+      const teamAbbrMap = new Map(allCBBTeams.map((team) => [team.ID, team.Abbr]));
       let foundMatch: CBBMatch[] | null = null;
       let gameWeek = currentWeek;
 
@@ -344,17 +345,16 @@ export const getLandingNFLData = (
         );
 
         homeLabel = isUserTeamHome
-          ? teamMatchUp[0].HomeTeam
-          : teamMatchUp[0].AwayTeam;
-        awayLabel = isUserTeamHome
-          ? teamMatchUp[0].AwayTeam
-          : teamMatchUp[0].HomeTeam;
+        ? teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown"
+        : teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown";
+      awayLabel = isUserTeamHome
+        ? teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown"
+        : teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown";
 
         gameLocation = isUserTeamHome ? "VS" : "AT";
       }
   
       // Team Schedule
-      const teamAbbrMap = new Map(allCBBTeams.map((team) => [team.ID, team.Abbr]));
       const teamSchedule = allCBBGames
         .filter((game) => game.HomeTeamID === team.ID || 
                           game.AwayTeamID === team.ID)
@@ -424,6 +424,7 @@ export const getLandingNFLData = (
           .reverse();
         
         // Team Match-Up
+        const teamAbbrMap = new Map(allNBATeams.map((team) => [team.ID, team.Abbr]));
         let foundMatch: NBAMatch[] | null = null;
         let gameWeek = currentWeek;
 
@@ -464,17 +465,16 @@ export const getLandingNFLData = (
           );
 
           homeLabel = isUserTeamHome
-            ? teamMatchUp[0].HomeTeam
-            : teamMatchUp[0].AwayTeam;
-          awayLabel = isUserTeamHome
-            ? teamMatchUp[0].AwayTeam
-            : teamMatchUp[0].HomeTeam;
+          ? teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown"
+          : teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown";
+        awayLabel = isUserTeamHome
+          ? teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown"
+          : teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown";
 
           gameLocation = isUserTeamHome ? "VS" : "AT";
         }
   
         // Team Schedule
-        const teamAbbrMap = new Map(allNBATeams.map((team) => [team.ID, team.Abbr]));
         const teamSchedule = allNBAGames
           .filter((game) => game.HomeTeamID === team.ID || 
                             game.AwayTeamID === team.ID)
@@ -543,6 +543,7 @@ export const getLandingNFLData = (
         .reverse();
 
       // Team Match-Up
+      const teamAbbrMap = new Map(chlTeams.map((team) => [team.ID, team.Abbreviation]));
       let foundMatch: CHLGame[] | null = null;
       let gameWeek = currentWeek;
 
@@ -583,17 +584,16 @@ export const getLandingNFLData = (
         );
 
         homeLabel = isUserTeamHome
-          ? teamMatchUp[0].HomeTeam
-          : teamMatchUp[0].AwayTeam;
+        ? teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown"
+        : teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown";
         awayLabel = isUserTeamHome
-          ? teamMatchUp[0].AwayTeam
-          : teamMatchUp[0].HomeTeam;
+        ? teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown"
+        : teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown";
 
         gameLocation = isUserTeamHome ? "VS" : "AT";
       }
       
       // Team Schedule
-      const teamAbbrMap = new Map(chlTeams.map((team) => [team.ID, team.Abbreviation]));
       const teamSchedule = allCHLGames
         .filter((game) => game.HomeTeamID === team.ID || 
                           game.AwayTeamID === team.ID)
@@ -660,6 +660,7 @@ export const getLandingNFLData = (
         .reverse();
 
       // Team Match-Up
+      const teamAbbrMap = new Map(phlTeams.map((team) => [team.ID, team.Abbreviation]));
       let foundMatch: PHLGame[] | null = null;
       let gameWeek = currentWeek;
 
@@ -700,17 +701,16 @@ export const getLandingNFLData = (
         );
 
         homeLabel = isUserTeamHome
-          ? teamMatchUp[0].HomeTeam
-          : teamMatchUp[0].AwayTeam;
+        ? teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown"
+        : teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown";
         awayLabel = isUserTeamHome
-          ? teamMatchUp[0].AwayTeam
-          : teamMatchUp[0].HomeTeam;
+        ? teamAbbrMap.get(teamMatchUp[0].AwayTeamID) || "Unknown"
+        : teamAbbrMap.get(teamMatchUp[0].HomeTeamID) || "Unknown";
 
         gameLocation = isUserTeamHome ? "VS" : "AT";
       }
       
       // Team Schedule
-      const teamAbbrMap = new Map(phlTeams.map((team) => [team.ID, team.Abbreviation]));
       const teamSchedule = allPHLGames
         .filter((game) => game.HomeTeamID === team.ID || 
                           game.AwayTeamID === team.ID)


### PR DESCRIPTION
This relates to a bug fix for the match up component on the landing page, and also some spacing adjustments for the game bar.

- Landing page match up component now fixed, fully functional. I've tested this with both home, and away wins/losses and it works correctly.
  - It now also utilises team abbreviations to help with spacing.
- Adjusted game bar width so it utilises the correct space.