### PR TITLE
Colour and component upgrades

### DIFF
--- a/src/_design/SectionCards.tsx
+++ b/src/_design/SectionCards.tsx
@@ -10,6 +10,7 @@ interface SectionCardsProps {
   team: any;
   classes?: string;
   backgroundColor: string;
+  headerColor: string;
   darkerBackgroundColor: string;
   borderColor: string;
   textColorClass: string;
@@ -21,16 +22,18 @@ export const SectionCards: React.FC<SectionCardsProps> = ({
   team,
   classes="bg-[#1f2937]",
   backgroundColor,
+  headerColor,
   darkerBackgroundColor,
   textColorClass,
   borderColor
 }) => {
+  const headerTextColorClass = getTextColorBasedOnBg(headerColor)
   
   return (
     <div className={`flex flex-col rounded-lg p-4 max-w-[50em] h-full shadow-md border-2 ${classes}`}
-      style={{ borderColor, backgroundColor }}>
-      <div className="mb-4 rounded-md" style={{ backgroundColor, borderColor }}>
-        <Text variant="h4" className={`font-semibold rounded-md ${textColorClass}`}>
+      style={{ borderColor: headerColor, backgroundColor }}>
+      <div className="mb-4 rounded-md" style={{ backgroundColor: headerColor, borderColor: headerColor }}>
+        <Text variant="h4" className={`font-semibold rounded-md py-1 ${headerTextColorClass}`}>
           {header}
         </Text>
       </div>

--- a/src/_design/Table.tsx
+++ b/src/_design/Table.tsx
@@ -41,10 +41,10 @@ export const Table = <T,>({
   rowBgColor,
   darkerRowBgColor
 }: TableProps<T>): JSX.Element => {
-  let backgroundColor = team?.ColorOne || "#4B5563";
+  let backgroundColor = "#1f2937";
   let borderColor = team?.ColorTwo || "#4B5563";
-  let tableBgColor = rowBgColor || "#242424";
-  let darkerTableBgColor = darkerRowBgColor || darkenColor(tableBgColor, 5) || "#242424";
+  let tableBgColor = rowBgColor || "#1f2937";
+  let darkerTableBgColor = darkerRowBgColor || darkenColor(tableBgColor, -5) || "#1f2937";
   if (isBrightColor(backgroundColor)) {
     [backgroundColor, borderColor] = [borderColor, backgroundColor];
   }
@@ -93,7 +93,7 @@ export const Table = <T,>({
   };
 
   return (
-    <div className="overflow-x-auto rounded-lg w-full">
+    <div className="overflow-x-auto w-full">
       <div
         className={`sm:table table-auto w-full border-b-2`}
         style={{ backgroundColor, borderColor }}
@@ -102,14 +102,14 @@ export const Table = <T,>({
         <div className="table-header-group sticky top-0">
           <div
             className={`table-row text-left ${textColorClass}`}
-            style={{ backgroundColor: darkerBackgroundColor, borderColor }}
+            style={{ backgroundColor: backgroundColor, borderColor }}
           >
             {columns.map((col) => (
               <div
                 key={col.accessor}
                 className="table-cell border-b-2 px-2 py-2 font-semibold whitespace-nowrap cursor-pointer"
                 style={{
-                  backgroundColor: darkerBackgroundColor,
+                  backgroundColor: backgroundColor,
                   borderColor: borderColor,
                 }}
                 onClick={() => handleSort(col.accessor)}
@@ -127,7 +127,7 @@ export const Table = <T,>({
         {/* Body */}
         <div className="table-row-group">
           {sortedData.map((item, index) => {
-          const bg = index % 2 === 0 ? tableBgColor : darkerTableBgColor;
+          const bg = index % 2 === 0 ? darkerTableBgColor : tableBgColor;
             return (
               <React.Fragment key={index}>
                 {rowRenderer(item, index, bg)}

--- a/src/_hooks/useSelectStyles.tsx
+++ b/src/_hooks/useSelectStyles.tsx
@@ -47,4 +47,8 @@ export const selectStyles = <IsMulti extends boolean = false>(): StylesConfig<
     ...provided,
     color: "#A0AEC0",
   }),
+  input: (provided) => ({
+    ...provided,
+    color: "#ffffff",
+  }),
 });

--- a/src/components/Common/Tables.tsx
+++ b/src/components/Common/Tables.tsx
@@ -82,8 +82,6 @@ export const StandingsTable = ({
       data={standings}
       rowRenderer={rowRenderer}
       team={team}
-      rowBgColor={rowBgColor}
-      darkerRowBgColor={darkerRowBgColor}
     />
   );
 };

--- a/src/components/LandingPage/TeamLandingPage.tsx
+++ b/src/components/LandingPage/TeamLandingPage.tsx
@@ -37,10 +37,11 @@ interface TeamLandingPageProps {
 
 export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
   const { currentUser } = useAuthStore();
-  let backgroundColor = team?.ColorOne || "#4B5563";
+  let backgroundColor = "#1f2937";
+  let headerColor = team?.ColorOne || "#4B5563";
   let borderColor = team?.ColorTwo || "#4B5563";
-    if (isBrightColor(backgroundColor)) {
-      [backgroundColor, borderColor] = [borderColor, backgroundColor];
+    if (isBrightColor(headerColor)) {
+      [headerColor, borderColor] = [borderColor, headerColor];
     }
   let darkerBackgroundColor = darkenColor(backgroundColor, -5)
   const textColorClass = getTextColorBasedOnBg(backgroundColor)
@@ -291,6 +292,7 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
                   ts={ts} 
                   currentUser={currentUser} 
                   backgroundColor={backgroundColor} 
+                  headerColor={headerColor}
                   borderColor={borderColor}
         />
         <div className="flex-col md:flex md:flex-row gap-4 items-start w-full justify-center">
@@ -309,6 +311,7 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
                               currentUser={currentUser}
                               isLoadingTwo={isLoadingTwo}
                               backgroundColor={backgroundColor}
+                              headerColor={headerColor}
                               borderColor={borderColor}
                               textColorClass={textColorClass}
                               darkerBackgroundColor={darkerBackgroundColor}  
@@ -333,6 +336,7 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
                             homeLabel={homeLabel}
                             awayLabel={awayLabel}
                             backgroundColor={backgroundColor}
+                            headerColor={headerColor}
                             borderColor={borderColor}
                             textColorClass={textColorClass}
                             darkerBackgroundColor={darkerBackgroundColor}  
@@ -350,6 +354,7 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
                   <TeamMailbox team={team}
                               notifications={teamNotifications}
                               backgroundColor={backgroundColor}
+                              headerColor={headerColor}
                               borderColor={borderColor}
                               textColorClass={textColorClass}
                               darkerBackgroundColor={darkerBackgroundColor}  
@@ -366,6 +371,7 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
                   <TeamNews team={team}
                                 teamNews={teamNews}
                                 backgroundColor={backgroundColor}
+                                headerColor={headerColor}
                                 borderColor={borderColor}
                                 textColorClass={textColorClass}
                                 darkerBackgroundColor={darkerBackgroundColor}  
@@ -375,7 +381,7 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
               </div>
             </div>
           </div>
-          <div className="flex md:flex-col items-center pt-1 md:pt-0 h-[28em] md:h-auto md:w-auto md:min-w-[20em] md:max-w-[30em] 3xl:min-w-[26em] 3xl:max-w-[42em] justify-center gap-1">
+          <div className="flex md:flex-col items-center pt-1 md:pt-0 h-[28em] md:h-auto md:w-auto md:min-w-[20em] md:max-w-[30em] 3xl:min-w-[26em] 3xl:max-w-[42em] justify-center gap-3">
             <Border
                 classes="border-4 h-full md:h-auto py-[0px] px-[0px] w-[70%] md:w-full md:min-w-[18em] md:max-w-[30em] md:max-h-[35em]"
                 styles={{
@@ -389,6 +395,7 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
                           teamStats={teamStats}
                           titles={headers}
                           backgroundColor={backgroundColor}
+                          headerColor={headerColor}
                           borderColor={borderColor}
                           textColorClass={textColorClass}
                           darkerBackgroundColor={darkerBackgroundColor}  
@@ -408,6 +415,7 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
                   ts={ts}
                   currentUser={currentUser}
                   backgroundColor={backgroundColor}
+                  headerColor={headerColor}
                   borderColor={borderColor}
                   textColorClass={textColorClass}
                   darkerBackgroundColor={darkerBackgroundColor}  

--- a/src/components/LandingPage/TeamLandingPageComponents.tsx
+++ b/src/components/LandingPage/TeamLandingPageComponents.tsx
@@ -566,7 +566,7 @@ export const TeamStats = ({ team, league, header, teamStats, titles,
                style={{ borderColor: headerColor, backgroundColor: darkerBackgroundColor }}>
             <div className="flex">
               <div className={`flex my-1 items-center justify-center 
-                                    px-3 h-[3rem] min-h-[3rem] md:h-[7rem] rounded-lg border-2`} 
+                                    px-3 h-[3rem] min-h-[3rem] max-w-[3rem] md:h-[7rem] md:max-h-[8rem] md:max-w-[8rem] rounded-lg border-2`} 
                                     style={{ borderColor: borderColor, backgroundColor: "white" }}>
                 {boxOne.id !== undefined && (
                 <PlayerPicture team={team} playerID={boxOne.id} league={league} />
@@ -602,7 +602,7 @@ export const TeamStats = ({ team, league, header, teamStats, titles,
                style={{ borderColor: headerColor, backgroundColor: darkerBackgroundColor }}>
             <div className="flex">
               <div className={`flex my-1 items-center justify-center 
-                                    px-3 h-[3rem] min-h-[3rem] md:h-[7rem] rounded-lg border-2`} 
+                                    px-3 h-[3rem] min-h-[3rem] max-w-[3rem] md:h-[7rem] md:max-h-[8rem] md:max-w-[8rem] rounded-lg border-2`} 
                                     style={{ borderColor: borderColor, backgroundColor: "white" }}>
                 {boxTwo.id !== undefined && (
                 <PlayerPicture team={team} playerID={boxTwo.id} league={league} />
@@ -639,7 +639,7 @@ export const TeamStats = ({ team, league, header, teamStats, titles,
             
             <div className="flex">
               <div className={`flex my-1 items-center justify-center 
-                                    px-3 h-[3rem] min-h-[3rem] md:h-[7rem] rounded-lg border-2`} 
+                                    px-3 h-[3rem] min-h-[3rem] max-w-[3rem] md:h-[7rem] md:max-h-[8rem] md:max-w-[8rem] rounded-lg border-2`} 
                                     style={{ borderColor: borderColor, backgroundColor: "white" }}>
                 {boxThree.id !== undefined && (
                 <PlayerPicture team={team} playerID={boxThree.id} league={league} />

--- a/src/components/LandingPage/TeamLandingPageComponents.tsx
+++ b/src/components/LandingPage/TeamLandingPageComponents.tsx
@@ -11,6 +11,7 @@ import { Button } from "../../_design/Buttons";
 import { League } from "../../_constants/constants";
 import PlayerPicture from "../../_utility/usePlayerFaces";
 import { getLandingBoxStats } from "./TeamLandingPageHelper";
+import { SimCFB, SimNFL } from "../../_constants/constants";
 
 interface GamesBarProps {
   games: any[];
@@ -20,11 +21,12 @@ interface GamesBarProps {
   currentUser: any;
   backgroundColor: string;
   borderColor: string;
+  headerColor: string;
 }
 
 export const GamesBar = ({ games, league, team, ts, 
                            currentUser, backgroundColor, 
-                           borderColor }: 
+                           borderColor, headerColor }: 
                            GamesBarProps) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -86,7 +88,7 @@ export const GamesBar = ({ games, league, team, ts,
     return (
       <div key={index} 
            className={`flex flex-col rounded-lg items-center border pb-1 px-2 md:w-28 3xl:w-48 ${resultColor}`} 
-           style={{ borderColor: backgroundColor }}>
+           style={{ borderColor: headerColor }}>
         <div className="flex-col px-2 overflow-auto">
           <div className="flex-col items-center justify-center">
             <Logo variant="xs" containerClass="pb-1 max-w-[4em]" url={opponentLogoUrl} />
@@ -110,7 +112,7 @@ export const GamesBar = ({ games, league, team, ts,
           <button
             onClick={scrollLeft}
             className="absolute left-0 z-10 p-2 rounded-full border-1"
-            style={{ backgroundColor: backgroundColor, color: borderColor, borderColor: borderColor }}
+            style={{ backgroundColor: backgroundColor, color: borderColor, borderColor: headerColor }}
           >
             &lt;
           </button>
@@ -124,7 +126,7 @@ export const GamesBar = ({ games, league, team, ts,
           <button
             onClick={scrollRight}
             className="absolute right-0 z-10 p-2 rounded-full border-1"
-            style={{ backgroundColor: backgroundColor, color: borderColor, borderColor: borderColor }}
+            style={{ backgroundColor: backgroundColor, color: borderColor, borderColor: headerColor }}
           >
             &gt;
           </button>
@@ -141,6 +143,7 @@ interface TeamStandingsProps {
   currentUser: any;
   isLoadingTwo: boolean;
   backgroundColor: string;
+  headerColor: string;
   borderColor: string;
   textColorClass: string;
   darkerBackgroundColor: string;
@@ -148,7 +151,7 @@ interface TeamStandingsProps {
 
 export const TeamStandings = ({ standings, team, 
                                 league, currentUser, isLoadingTwo, 
-                                backgroundColor, borderColor, textColorClass, darkerBackgroundColor }: 
+                                backgroundColor, headerColor, borderColor, textColorClass, darkerBackgroundColor }: 
                                 TeamStandingsProps) => {
   
   return(
@@ -157,6 +160,7 @@ export const TeamStandings = ({ standings, team,
         header={`${team.Conference} Standings`}
         classes={`${textColorClass}, h-full`}
         backgroundColor={backgroundColor}
+        headerColor={headerColor}
         borderColor={borderColor}
         darkerBackgroundColor={darkerBackgroundColor}
         textColorClass={textColorClass}
@@ -192,6 +196,7 @@ interface TeamMatchUpProps {
   homeLabel: string;
   awayLabel: string;
   backgroundColor: string;
+  headerColor: string;
   borderColor: string;
   textColorClass: string;
   darkerBackgroundColor: string;
@@ -209,6 +214,7 @@ export const TeamMatchUp = ({
   homeLabel,
   awayLabel,
   backgroundColor,
+  headerColor,
   borderColor,
   textColorClass,
   darkerBackgroundColor,
@@ -244,10 +250,10 @@ export const TeamMatchUp = ({
       header={`Next Game`}
       classes={`${textColorClass}`}
       backgroundColor={backgroundColor}
+      headerColor={headerColor}
       borderColor={borderColor}
       textColorClass={textColorClass}
       darkerBackgroundColor={darkerBackgroundColor}
-
     >
       {isLoadingTwo ? (
         <div className="flex justify-center items-center pb-2">
@@ -257,38 +263,50 @@ export const TeamMatchUp = ({
         </div>
       ) : matchUp.length > 0 ? (
         <>
-          <div className="flex justify-center">
-            <div className="flex-col pb-2">
-              <Logo variant="large" containerClass="max-w-24 w-24" url={homeLogo} />
+          <div className="grid grid-cols-7 items-center text-center pb-4">
+            <div className="flex justify-end col-span-3">
+              <div className="flex flex-col items-center">
+                <Logo variant="large" 
+                      containerClass="max-w-24 w-24" 
+                      url={homeLogo} />
+                <Text
+                  variant="small"
+                  classes={`${textColorClass} font-semibold`}
+                  className="pr-1"
+                >
+                  {homeLabel}
+                </Text>
+                <Text variant="xs" 
+                      classes="opacity-70">
+                  {`HC ${coaches[0]}`}
+                </Text>
+              </div>
+            </div>
+            <div className="flex flex-col col-span-1 items-center">
               <Text
                 variant="small"
                 classes={`${textColorClass} font-semibold`}
-                className="pr-1"
               >
-                {homeLabel}
-              </Text>
-              <Text variant="xs" classes="opacity-70">
-                {`HC ${coaches[0]}`}
+                {gameLocation}
               </Text>
             </div>
-            <Text
-              variant="small"
-              classes={`${textColorClass} self-center font-semibold`}
-            >
-              {gameLocation}
-            </Text>
-            <div className="flex-col">
-              <Logo variant="large" containerClass="max-w-24" url={awayLogo} />
-              <Text
-                variant="small"
-                classes={`${textColorClass} font-semibold`}
-                className="pl-1"
-              >
-                {awayLabel}
-              </Text>
-              <Text variant="xs" classes="opacity-70">
-                {`HC ${coaches[1]}`}
-              </Text>
+            <div className="flex justify-start col-span-3">
+              <div className="flex flex-col items-center">
+                <Logo variant="large" 
+                      containerClass="max-w-24 w-24" 
+                      url={awayLogo} />
+                <Text
+                  variant="small"
+                  classes={`${textColorClass} font-semibold`}
+                  className="pl-1"
+                >
+                  {awayLabel}
+                </Text>
+                <Text variant="xs" 
+                      classes="opacity-70">
+                  {`HC ${coaches[1]}`}
+                </Text>
+              </div>
             </div>
           </div>
           <div className="flex-col items-center">
@@ -298,15 +316,17 @@ export const TeamMatchUp = ({
                 classes={`${resultColor} font-semibold`}
                 style={{
                   textShadow: `0.5px 0.5px 0 ${borderColor}, 
-                               -0.5px -0.5px 0 ${borderColor}, 
-                               0.5px -0.5px 0 ${borderColor}, 
-                               -0.5px 0.5px 0 ${borderColor}`,
+                              -0.5px -0.5px 0 ${borderColor}, 
+                              0.5px -0.5px 0 ${borderColor}, 
+                              -0.5px 0.5px 0 ${borderColor}`,
                 }}
               >
                 {`${gameScore}`}
               </Text>
             )}
-            <Text variant="small">{`Week ${week}`}</Text>
+            <Text variant="small">
+              {`Week ${week}`}
+            </Text>
             <Text variant="small">
               {matchUp[0].IsConference
                 ? matchUp[0].IsDivisional
@@ -339,6 +359,7 @@ interface TeamOverviewProps {
   ts: any;
   currentUser: any;
   backgroundColor: string;
+  headerColor: string;
   borderColor: string;
   textColorClass: string;
   darkerBackgroundColor: string;
@@ -346,16 +367,17 @@ interface TeamOverviewProps {
 }
 
 export const TeamOverview = ({ team, league, ts, 
-                           currentUser, backgroundColor, 
+                           currentUser, backgroundColor, headerColor, 
                            borderColor, textColorClass, darkerBackgroundColor, isLoadingTwo }: 
                            TeamOverviewProps) => {
-  
+  console.log(league)
   return (
     <SectionCards
                 team={team}
                 header="Team Grades"
                 classes={`${textColorClass} h-full`}
                 backgroundColor={backgroundColor}
+                headerColor={headerColor}
                 borderColor={borderColor}
                 textColorClass={textColorClass}
                 darkerBackgroundColor={darkerBackgroundColor}
@@ -368,59 +390,78 @@ export const TeamOverview = ({ team, league, ts,
       </div>
     ) : (
       <div className="flex-col p-1 md:p-3">
-        <div className="flex-col">
+        <div className="flex flex-col sm:flex-row justify-center sm:items-end sm:gap-4">
+          <div className="flex flex-col py-1 pb-4 sm:pb-1 items-center">
+            <div className={`flex items-center justify-center 
+                              size-12 md:size-16 rounded-full border-2`} 
+                              style={{ borderColor: headerColor, backgroundColor: darkerBackgroundColor }}>
+              <Text variant="body" 
+                    classes={`${textColorClass} font-semibold`}>
+                      {team.OverallGrade ? team.OverallGrade : "-"}
+              </Text>
+            </div>
+            <Text
+              variant="alternate"
+              classes={`${textColorClass} font-semibold 
+                        whitespace-nowrap`}
+            >
+              OVR
+            </Text>
+          </div>
           <div className="flex md:flex-row flex-col py-1 gap-4 justify-center">
             <div className="flex flex-col py-1 items-center">
-              <div className={`flex items-center justify-center 
-                                size-12 md:size-16 rounded-full border-2`} 
-                                style={{ borderColor: borderColor, backgroundColor: darkerBackgroundColor }}>
-                <Text variant="body" 
-                      classes={`${textColorClass} font-semibold`}>
-                        {team.OverallGrade ? team.OverallGrade : "N/A"}
-                </Text>
-              </div>
-              <Text
-                variant="alternate"
-                classes={`${textColorClass} font-semibold 
-                          whitespace-nowrap`}
-              >
-                Overall
-              </Text>
-            </div>
-            <div className="flex flex-col py-1 items-center">
-              <div className={`flex items-center justify-center size-12 md:size-16
+              <div className={`flex items-center justify-center size-8 md:size-12
                                rounded-full border-2`} 
-                                style={{ borderColor: borderColor, backgroundColor: darkerBackgroundColor }}>
-                <Text variant="body" 
+                                style={{ borderColor: headerColor, backgroundColor: darkerBackgroundColor }}>
+                <Text variant="small" 
                       classes={`${textColorClass} font-semibold`}>
-                        {team.OffenseGrade ? team.OffenseGrade : "N/A"}
+                        {team.OffenseGrade ? team.OffenseGrade : "-"}
                 </Text>
               </div>
               <Text
-                variant="alternate"
+                variant="small"
                 classes={`${textColorClass} font-semibold whitespace-nowrap`}
               >
-                Offense
+                OFF
               </Text>
             </div>
             <div className="flex flex-col py-1 items-center">
               <div className={`flex items-center justify-center 
-                                size-12 md:size-16 rounded-full border-2`} 
-                                style={{ borderColor: borderColor, backgroundColor: darkerBackgroundColor }}>
-                <Text variant="body" 
+                                size-8 md:size-12 rounded-full border-2`} 
+                                style={{ borderColor: headerColor, backgroundColor: darkerBackgroundColor }}>
+                <Text variant="small" 
                       classes=
                       {`${textColorClass} font-semibold`}>
-                        {team.DefenseGrade ? team.DefenseGrade : "N/A"}
+                        {team.DefenseGrade ? team.DefenseGrade : "-"}
                 </Text>
               </div>
               <Text
-                variant="alternate"
+                variant="small"
                 classes={`${textColorClass} 
                           font-semibold whitespace-nowrap`}
               >
-                Defense
+                DEF
               </Text>
             </div>
+          {team.SpecialTeamsGrade && (
+            <div className="flex flex-col py-1 items-center">
+              <div className={`flex items-center justify-center 
+                                size-8 md:size-12 rounded-full border-2`} 
+                                style={{ borderColor: headerColor, backgroundColor: darkerBackgroundColor }}>
+                <Text variant="small" 
+                      classes={`${textColorClass} font-semibold`}>
+                        {team.SpecialTeamsGrade ? team.SpecialTeamsGrade : "-"}
+                </Text>
+              </div>
+              <Text
+                variant="small"
+                classes={`${textColorClass} font-semibold 
+                          whitespace-nowrap`}
+              >
+                STU
+              </Text>
+            </div>
+          )}
           </div>
         </div>
       </div>
@@ -433,6 +474,7 @@ interface TeamMailboxProps {
   team: any;
   notifications: any[];
   backgroundColor: string;
+  headerColor: string;
   borderColor: string;
   textColorClass: string;
   darkerBackgroundColor: string;
@@ -440,7 +482,7 @@ interface TeamMailboxProps {
 }
 
 export const TeamMailbox = ({ team, notifications,
-                              backgroundColor, borderColor, textColorClass, darkerBackgroundColor, isLoadingTwo }:
+                              backgroundColor, headerColor, borderColor, textColorClass, darkerBackgroundColor, isLoadingTwo }:
                               TeamMailboxProps) => {
 
   return (
@@ -448,6 +490,7 @@ export const TeamMailbox = ({ team, notifications,
                   header="Team Inbox" 
                   classes={`${textColorClass} h-full`}
                   backgroundColor={backgroundColor}
+                  headerColor={headerColor}
                   borderColor={borderColor}
                   textColorClass={textColorClass}
                   darkerBackgroundColor={darkerBackgroundColor}
@@ -486,6 +529,7 @@ interface TeamStatsProps {
   teamStats: any;
   titles: any;
   backgroundColor: string;
+  headerColor: string;
   borderColor: string;
   textColorClass: string;
   darkerBackgroundColor: string;
@@ -493,7 +537,7 @@ interface TeamStatsProps {
 }
 
 export const TeamStats = ({ team, league, header, teamStats, titles,
-                            backgroundColor, borderColor, textColorClass, darkerBackgroundColor, isLoadingTwo }:
+                            backgroundColor, headerColor, borderColor, textColorClass, darkerBackgroundColor, isLoadingTwo }:
                               TeamStatsProps) => {
 
   const { boxOne, boxTwo, boxThree } = getLandingBoxStats(league, teamStats);
@@ -504,6 +548,7 @@ export const TeamStats = ({ team, league, header, teamStats, titles,
     header={header}
     classes={`${textColorClass}`}
     backgroundColor={backgroundColor}
+    headerColor={headerColor}
     borderColor={borderColor}
     textColorClass={textColorClass}
     darkerBackgroundColor={darkerBackgroundColor}
@@ -518,26 +563,30 @@ export const TeamStats = ({ team, league, header, teamStats, titles,
       ) : Object.keys(teamStats).length > 0 ? (
         <div className="flex-col items-center justify-center py-3 space-y-2 md:space-y-4">
           <div className={`flex-col items-center p-2 rounded-lg border-2`}
-               style={{ borderColor: borderColor, backgroundColor: darkerBackgroundColor }}>
-            <Text variant="body" classes={`${textColorClass} font-semibold`}>{titles[0]}</Text>
+               style={{ borderColor: headerColor, backgroundColor: darkerBackgroundColor }}>
             <div className="flex">
               <div className={`flex my-1 items-center justify-center 
-                                    px-3 h-[3rem] min-h-[3rem] md:h-[5rem] rounded-lg border-2`} 
+                                    px-3 h-[3rem] min-h-[3rem] md:h-[7rem] rounded-lg border-2`} 
                                     style={{ borderColor: borderColor, backgroundColor: "white" }}>
                 {boxOne.id !== undefined && (
                 <PlayerPicture team={team} playerID={boxOne.id} league={league} />
                 )}
               </div>
               <div className="flex-col w-3/4">
+                <Text variant="body" classes={`${textColorClass} font-semibold`}>
+                  {titles[0]}
+                </Text>
+                <div className="flex w-3/4 py-0.5 border-b mx-auto"
+                     style={{borderColor }} />
                 <div className="flex space-x-1 justify-center">
+                  <Text variant="small" classes={`${textColorClass} opacity-85`}>
+                    {`${boxOne.position}`}
+                  </Text>
                   <Text variant="small" classes={`${textColorClass} font-semibold text-center`}>
                     {`${boxOne.firstName}`}
                   </Text>
                   <Text variant="small" classes={`${textColorClass} font-semibold text-center`}>
                   {`${boxOne.lastName}`}
-                  </Text>
-                  <Text variant="small" classes={`${textColorClass} opacity-85`}>
-                    {`${boxOne.position}`}
                   </Text>
                 </div>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
@@ -550,26 +599,30 @@ export const TeamStats = ({ team, league, header, teamStats, titles,
             </div>
           </div>
           <div className={`flex-col items-center p-2 rounded-lg border-2`}
-               style={{ borderColor: borderColor, backgroundColor: darkerBackgroundColor }}>
-            <Text variant="body" classes={`${textColorClass} font-semibold`}>{titles[1]}</Text>
+               style={{ borderColor: headerColor, backgroundColor: darkerBackgroundColor }}>
             <div className="flex">
               <div className={`flex my-1 items-center justify-center 
-                                    px-3 h-[3rem] min-h-[3rem] md:h-[5rem] rounded-lg border-2`} 
+                                    px-3 h-[3rem] min-h-[3rem] md:h-[7rem] rounded-lg border-2`} 
                                     style={{ borderColor: borderColor, backgroundColor: "white" }}>
                 {boxTwo.id !== undefined && (
                 <PlayerPicture team={team} playerID={boxTwo.id} league={league} />
                 )}
               </div>
               <div className="flex-col w-3/4">
+                <Text variant="body" classes={`${textColorClass} font-semibold`}>
+                  {titles[1]}
+                </Text>
+                <div className="flex w-3/4 py-0.5 border-b mx-auto"
+                     style={{borderColor }} />
                 <div className="flex space-x-1 justify-center">
+                  <Text variant="small" classes={`${textColorClass} opacity-85`}>
+                    {`${boxTwo.position}`}
+                  </Text>
                   <Text variant="small" classes={`${textColorClass} font-semibold text-center`}>
                     {`${boxTwo.firstName}`}
                   </Text>
                   <Text variant="small" classes={`${textColorClass} font-semibold text-center`}>
                     {`${boxTwo.lastName}`}
-                  </Text>
-                  <Text variant="small" classes={`${textColorClass} opacity-85`}>
-                    {`${boxTwo.position}`}
                   </Text>
                 </div>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
@@ -582,26 +635,31 @@ export const TeamStats = ({ team, league, header, teamStats, titles,
             </div>
           </div>
           <div className={`flex-col items-center p-2 rounded-lg border-2`}
-               style={{ borderColor: borderColor, backgroundColor: darkerBackgroundColor }}>
-            <Text variant="body" classes={`${textColorClass} font-semibold`}>{titles[2]}</Text>
+               style={{ borderColor: headerColor, backgroundColor: darkerBackgroundColor }}>
+            
             <div className="flex">
               <div className={`flex my-1 items-center justify-center 
-                                    px-3 h-[3rem] min-h-[3rem] md:h-[5rem] rounded-lg border-2`} 
+                                    px-3 h-[3rem] min-h-[3rem] md:h-[7rem] rounded-lg border-2`} 
                                     style={{ borderColor: borderColor, backgroundColor: "white" }}>
                 {boxThree.id !== undefined && (
                 <PlayerPicture team={team} playerID={boxThree.id} league={league} />
                 )}
               </div>
               <div className="flex-col w-3/4">
+                <Text variant="body" classes={`${textColorClass} font-semibold`}>
+                  {titles[2]}
+                </Text>
+                <div className="flex w-3/4 py-0.5 border-b mx-auto"
+                     style={{borderColor }} />
                 <div className="flex space-x-1 justify-center">
+                  <Text variant="small" classes={`${textColorClass} opacity-85`}>
+                    {`${boxThree.position}`}
+                  </Text>
                   <Text variant="small" classes={`${textColorClass} font-semibold text-center`}>
                     {`${boxThree.firstName}`}
                   </Text>
                   <Text variant="small" classes={`${textColorClass} font-semibold text-center`}>
                     {`${boxThree.lastName}`}
-                  </Text>
-                  <Text variant="small" classes={`${textColorClass} opacity-85`}>
-                    {`${boxThree.position}`}
                   </Text>
                 </div>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
@@ -627,6 +685,7 @@ interface TeamNewsProps {
   team: any;
   teamNews: any[];
   backgroundColor: string;
+  headerColor: string;
   borderColor: string;
   textColorClass: string;
   darkerBackgroundColor: string;
@@ -634,7 +693,7 @@ interface TeamNewsProps {
 }
 
 export const TeamNews = ({ team, teamNews,
-                              backgroundColor, borderColor, textColorClass, darkerBackgroundColor, isLoadingTwo }:
+                              backgroundColor, headerColor, borderColor, textColorClass, darkerBackgroundColor, isLoadingTwo }:
                               TeamNewsProps) => {
 
   return (
@@ -642,6 +701,7 @@ export const TeamNews = ({ team, teamNews,
                   header="Team News" 
                   classes={`${textColorClass} h-full`}
                   backgroundColor={backgroundColor}
+                  headerColor={headerColor}
                   borderColor={borderColor}
                   textColorClass={textColorClass}
                   darkerBackgroundColor={darkerBackgroundColor}>

--- a/src/components/Team/TeamPage.tsx
+++ b/src/components/Team/TeamPage.tsx
@@ -40,10 +40,11 @@ import { useSimFBAStore } from "../../context/SimFBAContext";
 import { isBrightColor } from "../../_utility/isBrightColor";
 import { ActionModal } from "../Common/ActionModal";
 import { useMobile } from "../../_hooks/useMobile";
+import { darkenColor } from "../../_utility/getDarkerColor";
 
 interface TeamPageProps {
   league: League;
-  ts: any;
+  ts?: any;
 }
 
 export const TeamPage: FC<TeamPageProps> = ({ league }) => {
@@ -118,13 +119,13 @@ const CHLTeamPage = ({ league, ts }: TeamPageProps) => {
     selectedTeam?.ColorTwo,
     selectedTeam?.ColorThree
   );
-  let backgroundColor = teamColors.One;
+  let backgroundColor = "#1f2937";
+  let headerColor = teamColors.One;
   let borderColor = teamColors.Two;
-  const [isMobile] = useMobile();
-
-  if (isBrightColor(backgroundColor)) {
-    [backgroundColor, borderColor] = [borderColor, backgroundColor];
+  if (isBrightColor(headerColor)) {
+    [headerColor, borderColor] = [borderColor, headerColor];
   }
+  const [isMobile] = useMobile();
 
   const secondaryBorderColor = teamColors.Three;
   const selectedRoster = useMemo(() => {
@@ -175,6 +176,7 @@ const CHLTeamPage = ({ league, ts }: TeamPageProps) => {
           id={selectedTeam?.ID}
           isRetro={currentUser?.isRetro}
           League={league}
+          Team={selectedTeam}
           ts={ts}
           isPro={false}
           Roster={selectedRoster}
@@ -184,8 +186,9 @@ const CHLTeamPage = ({ league, ts }: TeamPageProps) => {
           Conference={selectedTeam?.Conference}
           Arena={selectedTeam?.Arena}
           Capacity={selectedTeam?.ArenaCapacity}
-          colorOne={backgroundColor}
-          colorTwo={borderColor}
+          backgroundColor={backgroundColor}
+          headerColor={headerColor}
+          borderColor={borderColor}
         />
       </div>
       <div className="flex flex-row md:flex-col w-full">
@@ -194,7 +197,7 @@ const CHLTeamPage = ({ league, ts }: TeamPageProps) => {
           classes="w-full p-2 gap-x-2"
           styles={{
             backgroundColor: backgroundColor,
-            borderColor,
+            borderColor: headerColor,
           }}
         >
           <div className="flex w-full">
@@ -243,15 +246,16 @@ const CHLTeamPage = ({ league, ts }: TeamPageProps) => {
           classes="px-2 lg:w-full min-[320px]:w-[95vw] min-[700px]:w-[775px] max-w-[2000px] overflow-x-auto max-[400px]:h-[60vh] max-[500px]:h-[55vh] h-[60vh]"
           styles={{
             backgroundColor: backgroundColor,
-            borderColor,
+            borderColor: headerColor,
           }}
         >
           <CHLRosterTable
             team={selectedTeam}
             roster={selectedRoster}
             category={category}
-            colorOne={backgroundColor}
-            colorTwo={borderColor}
+            backgroundColor={backgroundColor}
+            headerColor={headerColor}
+            borderColor={borderColor}
             openModal={openModal}
           />
         </Border>
@@ -284,10 +288,11 @@ const PHLTeamPage = ({ league, ts }: TeamPageProps) => {
     selectedTeam?.ColorTwo,
     selectedTeam?.ColorThree
   );
-  let backgroundColor = teamColors.One;
+  let backgroundColor = "#1f2937";
+  let headerColor = teamColors.One;
   let borderColor = teamColors.Two;
-  if (isBrightColor(backgroundColor)) {
-    [backgroundColor, borderColor] = [borderColor, backgroundColor];
+  if (isBrightColor(headerColor)) {
+    [headerColor, borderColor] = [borderColor, headerColor];
   }
   const secondaryBorderColor = teamColors.Three;
   const textColorClass = teamColors.TextColorOne;
@@ -375,6 +380,7 @@ const PHLTeamPage = ({ league, ts }: TeamPageProps) => {
           id={selectedTeam?.ID}
           isRetro={currentUser?.isRetro}
           Roster={selectedRoster}
+          Team={selectedTeam}
           League={league}
           ts={ts}
           isPro={true}
@@ -387,8 +393,9 @@ const PHLTeamPage = ({ league, ts }: TeamPageProps) => {
           Conference={selectedTeam?.Conference}
           Arena={selectedTeam?.Arena}
           Capacity={selectedTeam?.ArenaCapacity}
-          colorOne={backgroundColor}
-          colorTwo={borderColor}
+          backgroundColor={backgroundColor}
+          headerColor={headerColor}
+          borderColor={borderColor}
         />
       </div>
       <div className="flex flex-row md:flex-col w-full">
@@ -397,7 +404,7 @@ const PHLTeamPage = ({ league, ts }: TeamPageProps) => {
           classes="w-full p-2 gap-x-2"
           styles={{
             backgroundColor: backgroundColor,
-            borderColor,
+            borderColor: headerColor,
           }}
         >
           <div className="flex w-full">
@@ -454,7 +461,7 @@ const PHLTeamPage = ({ league, ts }: TeamPageProps) => {
         classes="px-2 lg:w-full min-[320px]:w-[95vw] min-[700px]:w-[775px] overflow-x-auto max-[400px]:h-[60vh] max-[500px]:h-[55vh] h-[60vh]"
         styles={{
           backgroundColor: backgroundColor,
-          borderColor,
+          borderColor: headerColor,
         }}
       >
         <PHLRosterTable
@@ -463,8 +470,9 @@ const PHLTeamPage = ({ league, ts }: TeamPageProps) => {
           ts={ts}
           team={selectedTeam}
           category={category}
-          colorOne={backgroundColor}
-          colorTwo={borderColor}
+          backgroundColor={backgroundColor}
+          headerColor={headerColor}
+          borderColor={borderColor}
           openModal={openModal}
         />
       </Border>
@@ -495,13 +503,13 @@ const CFBTeamPage = ({ league, ts }: TeamPageProps) => {
     selectedTeam?.ColorTwo,
     selectedTeam?.ColorThree
   );
-  let backgroundColor = teamColors.One;
+  let backgroundColor = "#1f2937";
+  let headerColor = teamColors.One;
   let borderColor = teamColors.Two;
-  const [isMobile] = useMobile();
-
-  if (isBrightColor(backgroundColor)) {
-    [backgroundColor, borderColor] = [borderColor, backgroundColor];
+  if (isBrightColor(headerColor)) {
+    [headerColor, borderColor] = [borderColor, headerColor];
   }
+  const [isMobile] = useMobile();
 
   const selectedRoster = useMemo(() => {
     if (selectedTeam && cfbRosterMap) {
@@ -554,6 +562,7 @@ const CFBTeamPage = ({ league, ts }: TeamPageProps) => {
           League={league}
           ts={ts}
           Roster={selectedRoster}
+          Team={selectedTeam}
           TeamProfile={selectedTeamProfile}
           isPro={false}
           TeamName={`${selectedTeam?.TeamName} ${selectedTeam?.Mascot}`}
@@ -561,8 +570,9 @@ const CFBTeamPage = ({ league, ts }: TeamPageProps) => {
           Conference={selectedTeam?.Conference}
           Arena={selectedTeam?.Stadium}
           Capacity={selectedTeam?.StadiumCapacity}
-          colorOne={backgroundColor}
-          colorTwo={borderColor}
+          backgroundColor={backgroundColor}
+          headerColor={headerColor}
+          borderColor={borderColor}
         />
       </div>
       <div className="flex flex-row md:flex-col w-full">
@@ -571,7 +581,7 @@ const CFBTeamPage = ({ league, ts }: TeamPageProps) => {
           classes="w-full p-2 gap-x-2"
           styles={{
             backgroundColor: backgroundColor,
-            borderColor,
+            borderColor: headerColor,
           }}
         >
           <div className="flex w-full">
@@ -610,15 +620,16 @@ const CFBTeamPage = ({ league, ts }: TeamPageProps) => {
           classes="px-2 lg:w-full min-[320px]:w-[95vw] min-[700px]:w-[775px] overflow-x-auto max-[400px]:h-[60vh] max-[500px]:h-[55vh] h-[60vh]"
           styles={{
             backgroundColor: backgroundColor,
-            borderColor,
+            borderColor: headerColor,
           }}
         >
           <CFBRosterTable
             roster={selectedRoster}
             team={selectedTeam}
             category={category}
-            colorOne={backgroundColor}
-            colorTwo={borderColor}
+            backgroundColor={backgroundColor}
+            headerColor={headerColor}
+            borderColor={borderColor}
             openModal={openModal}
           />
         </Border>
@@ -650,13 +661,14 @@ const NFLTeamPage = ({ league, ts }: TeamPageProps) => {
     selectedTeam?.ColorTwo,
     selectedTeam?.ColorThree
   );
-  let backgroundColor = teamColors.One;
+  let backgroundColor = "#1f2937";
+  let headerColor = teamColors.One;
   let borderColor = teamColors.Two;
-  const [isMobile] = useMobile();
-
-  if (isBrightColor(backgroundColor)) {
-    [backgroundColor, borderColor] = [borderColor, backgroundColor];
+  if (isBrightColor(headerColor)) {
+    [headerColor, borderColor] = [borderColor, headerColor];
   }
+  const [isMobile] = useMobile();
+  let darkerBackgroundColor = darkenColor(backgroundColor, -5)
 
   const selectedRoster = useMemo(() => {
     if (selectedTeam && nflRosterMap) {
@@ -736,6 +748,7 @@ const NFLTeamPage = ({ league, ts }: TeamPageProps) => {
           id={selectedTeam?.ID}
           isRetro={currentUser?.isRetro}
           Roster={selectedRoster}
+          Team={selectedTeam}
           League={league}
           ts={ts}
           isPro={true}
@@ -748,8 +761,9 @@ const NFLTeamPage = ({ league, ts }: TeamPageProps) => {
           Conference={selectedTeam?.Conference}
           Arena={selectedTeam?.Stadium}
           Capacity={selectedTeam?.StadiumCapacity}
-          colorOne={backgroundColor}
-          colorTwo={borderColor}
+          backgroundColor={backgroundColor}
+          headerColor={headerColor}
+          borderColor={borderColor}
         />
       </div>
       <div className="flex flex-row md:flex-col w-full">
@@ -758,7 +772,7 @@ const NFLTeamPage = ({ league, ts }: TeamPageProps) => {
           classes="w-full p-2 gap-x-2"
           styles={{
             backgroundColor: backgroundColor,
-            borderColor,
+            borderColor: headerColor,
           }}
         >
           <div className="flex w-full">
@@ -806,7 +820,7 @@ const NFLTeamPage = ({ league, ts }: TeamPageProps) => {
           classes="px-2 lg:w-full min-[320px]:w-[95vw] min-[700px]:w-[775px] overflow-x-auto max-[400px]:h-[60vh] max-[500px]:h-[55vh] h-[60vh]"
           styles={{
             backgroundColor: backgroundColor,
-            borderColor,
+            borderColor: headerColor,
           }}
         >
           <NFLRosterTable
@@ -815,8 +829,9 @@ const NFLTeamPage = ({ league, ts }: TeamPageProps) => {
             ts={ts}
             team={selectedTeam}
             category={category}
-            colorOne={backgroundColor}
-            colorTwo={borderColor}
+            backgroundColor={backgroundColor}
+            headerColor={headerColor}
+            borderColor={borderColor}
             openModal={openModal}
           />
         </Border>

--- a/src/components/Team/TeamPageComponents.tsx
+++ b/src/components/Team/TeamPageComponents.tsx
@@ -17,6 +17,7 @@ import { useMobile } from "../../_hooks/useMobile";
 interface TeamInfoProps {
   id?: number;
   TeamName?: string;
+  Team?: any;
   Owner?: string;
   Coach?: string;
   GM?: string;
@@ -32,8 +33,9 @@ interface TeamInfoProps {
   Capsheet?: any;
   League: League;
   ts: any;
-  colorOne?: string;
-  colorTwo?: string;
+  backgroundColor?: string;
+  headerColor?: string;
+  borderColor?: string;
   isRetro?: boolean;
 }
 
@@ -41,6 +43,7 @@ export const TeamInfo: FC<TeamInfoProps> = ({
   isPro,
   id,
   TeamName = "",
+  Team,
   Owner = "None",
   Coach = "None",
   GM = "None",
@@ -55,16 +58,12 @@ export const TeamInfo: FC<TeamInfoProps> = ({
   League,
   Roster,
   ts,
-  colorOne = "",
-  colorTwo = "",
+  backgroundColor,
+  headerColor,
+  borderColor,
   isRetro = false,
 }) => {
-  const backgroundColor = colorOne;
-  const borderColor = colorTwo;
-  const sectionBg = "#242424";
-  const darkerBorder = backgroundColor === "#000000" || borderColor === "rgb(0, 0, 0)"
-  ? darkenColor(backgroundColor, 5)
-  : darkenColor(backgroundColor, -5);
+  const sectionBg = darkenColor("#1f2937", -5);
   const textColorClass = getTextColorBasedOnBg(backgroundColor);
   const logo = getLogo(League, id!!, isRetro);
   const [isMobile] = useMobile();
@@ -75,7 +74,7 @@ export const TeamInfo: FC<TeamInfoProps> = ({
         classes="w-full p-8 justify-around"
         styles={{
           backgroundColor,
-          borderColor,
+          borderColor: headerColor,
         }}
       >            
       {!isMobile && (
@@ -87,15 +86,15 @@ export const TeamInfo: FC<TeamInfoProps> = ({
             scout={Scout} 
             isPro={isPro}
             marketing={Marketing} 
-            borderColor={borderColor} 
+            borderColor={headerColor} 
             backgroundColor={sectionBg}
             lineColor={borderColor} />
         </div>
         )}
-        <div className="flex flex-col sm:w-1/4 5xl:max-w-[10rem] justify-center items-center pb-2">
-          <div className="flex flex-col max-w-1/4 p-2">
+        <div className="flex flex-col sm:w-1/4 5xl:max-w-[10rem] justify-center items-center">
+          <div className="flex flex-col max-w-1/4 p-2 pt-6">
             <div className="max-w-[6rem] 5xl:max-w-[10rem] w-[5.5em] h-[5.5rem] rounded-lg border-2"
-                  style={{ backgroundColor: sectionBg, borderColor: borderColor }}>
+                  style={{ backgroundColor: sectionBg, borderColor: headerColor }}>
               <Logo url={logo} 
                     variant="large" />
             </div>
@@ -105,20 +104,25 @@ export const TeamInfo: FC<TeamInfoProps> = ({
                   classes={`${textColorClass}`}>
               {TeamName}
             </Text>
-            <div className="flex flex-row justify-center">
-              <Text variant="body-small" 
+            <div className="flex flex-row justify-center pb-2">
+              <Text variant="small" 
                     classes={`${textColorClass}`
                     }>
                 {Conference} Conference
               </Text>
               {Division && Division.length > 0 && (
-              <Text variant="body-small" 
+              <Text variant="xs" 
                     classes={`${textColorClass}`}>
                 {Division}
               </Text>
               )}
             </div>
           </div>
+          <TeamGrades Team={Team} 
+                      backgroundColor={sectionBg}
+                      gradeColor={backgroundColor} 
+                      borderColor={headerColor}
+          />
         </div>
         {!isMobile && (
         <div className="flex flex-col w-1/3 items-center justify-center gap-x-2">
@@ -127,7 +131,7 @@ export const TeamInfo: FC<TeamInfoProps> = ({
             capsheet={Capsheet} 
             ts={ts} 
             league={League}
-            borderColor={borderColor} 
+            borderColor={headerColor} 
             backgroundColor={sectionBg} 
           />
         )}
@@ -137,7 +141,8 @@ export const TeamInfo: FC<TeamInfoProps> = ({
             ts={ts}
             league={League}
             backgroundColor={sectionBg}
-            borderColor={borderColor}
+            borderColor={headerColor}
+            lineColor={borderColor}
           />
         )}
         </div>
@@ -148,7 +153,7 @@ export const TeamInfo: FC<TeamInfoProps> = ({
         classes="w-full h-[1em] max-h-[5em] p-4 sm:p-6 sm:px-14 justify-center sm:justify-around"
         styles={{
           backgroundColor,
-          borderColor,
+          borderColor: headerColor,
         }}
       >            
         <div className="flex w-full justify-center sm:justify-between items-center gap-x-2">
@@ -158,16 +163,16 @@ export const TeamInfo: FC<TeamInfoProps> = ({
             arena={Arena}
             capacity={Capacity}
             textColorClass={textColorClass}
-            borderColor={borderColor} 
-            backgroundColor={darkerBorder}
+            borderColor={headerColor} 
+            backgroundColor={backgroundColor}
             isPro={isPro} />
           )}
             <RosterInfo 
             roster={Roster} 
             league={League}
             textColorClass={textColorClass}
-            borderColor={borderColor} 
-            backgroundColor={darkerBorder}
+            borderColor={headerColor} 
+            backgroundColor={backgroundColor}
             isPro={isPro} />
         </div>
       </Border>
@@ -292,6 +297,7 @@ export const TeamBreakdown = ({
   league,
   backgroundColor,
   borderColor,
+  lineColor,
   textColorClass,
 }: any) => {
   return (
@@ -319,9 +325,10 @@ export const TeamBreakdown = ({
         </div>
       </div>
     )}
+    <div className="flex w-[90%] self-center border-t" 
+             style={{ borderColor: lineColor }} />
     {TeamProfile && ts && (
-      <div className="flex flex-col w-full border-t border-dotted pt-1 px-1" 
-           style={{ borderColor }}>
+      <div className="flex flex-col w-full pt-1 px-1">
         <Text variant="body-small" classes={`${textColorClass} font-semibold pb-1`}>
           Incoming Croots
         </Text>
@@ -549,3 +556,87 @@ export const StadiumInfo = ({ backgroundColor, borderColor, arena, capacity, lea
     </div>
   );
 };
+
+export const TeamGrades = ({ backgroundColor, gradeColor, borderColor, Team }: any) => {
+  return (
+    <div className="flex items-center w-full justify-center gap-5 p-2 sm:p-0 sm:pt-1 flex-shrink-1 rounded-lg border-2" 
+         style={{ backgroundColor, borderColor }}>
+    {Team && (
+      <div className="flex flex-col py-1 items-center">
+        <div className={`flex items-center justify-center 
+                          size-6 md:size-8 rounded-full border-2`} 
+                          style={{ borderColor, backgroundColor: gradeColor }}>
+          <Text variant="xs" 
+                classes={`font-semibold text-center`}>
+                  {Team.OverallGrade ? Team.OverallGrade : "-"}
+          </Text>
+        </div>
+        <Text
+          variant="xs"
+          classes={`font-semibold 
+                    whitespace-nowrap`}
+        >
+          OVR
+        </Text>
+      </div>
+    )}
+    {Team && (
+      <div className="flex flex-col py-1 items-center">
+        <div className={`flex items-center justify-center 
+                          size-6 md:size-8 rounded-full border-2`} 
+                          style={{ borderColor, backgroundColor: gradeColor }}>
+          <Text variant="xs" 
+                classes={`font-semibold`}>
+                  {Team.OffenseGrade ? Team.OffenseGrade : "-"}
+          </Text>
+        </div>
+        <Text
+          variant="xs"
+          classes={`font-semibold 
+                    whitespace-nowrap`}
+        >
+          OFF
+        </Text>
+      </div>
+    )}
+    {Team && (
+      <div className="flex flex-col py-1 items-center">
+        <div className={`flex items-center justify-center 
+                          size-6 md:size-8 rounded-full border-2`} 
+                          style={{ borderColor, backgroundColor: gradeColor }}>
+          <Text variant="xs" 
+                classes={`font-semibold text-center`}>
+                  {Team.DefenseGrade ? Team.DefenseGrade : "-"}
+          </Text>
+        </div>
+        <Text
+          variant="xs"
+          classes={`font-semibold 
+                    whitespace-nowrap`}
+        >
+          DEF
+        </Text>
+      </div>
+    )}
+    {Team.SpecialTeamsGrade && (
+      <div className="flex flex-col py-1 items-center">
+        <div className={`flex items-center justify-center 
+                          size-6 md:size-8 rounded-full border-2`} 
+                          style={{ borderColor, backgroundColor: gradeColor }}>
+          <Text variant="xs" 
+                classes={`font-semibold`}>
+                  {Team.SpecialTeamsGrade ? Team.SpecialTeamsGrade : "-"}
+          </Text>
+        </div>
+        <Text
+          variant="xs"
+          classes={`font-semibold 
+                    whitespace-nowrap`}
+        >
+          STU
+        </Text>
+      </div>
+    )}
+    </div>
+  )
+}

--- a/src/components/Team/TeamPageTables.tsx
+++ b/src/components/Team/TeamPageTables.tsx
@@ -20,8 +20,9 @@ import { CheckCircle, CrossCircle, ShieldCheck, User } from "../../_design/Icons
 
 interface CHLRosterTableProps {
   roster: CHLPlayer[];
-  colorOne?: string;
-  colorTwo?: string;
+  backgroundColor?: string;
+  headerColor?: string;
+  borderColor?: string;
   team?: any;
   category?: string;
   openModal: (action: ModalAction, player: CHLPlayer) => void;
@@ -29,14 +30,14 @@ interface CHLRosterTableProps {
 
 export const CHLRosterTable: FC<CHLRosterTableProps> = ({
   roster,
-  colorOne,
-  colorTwo,
+  backgroundColor,
+  headerColor,
+  borderColor,
   team,
   category,
   openModal,
 }) => {
-  const backgroundColor = colorOne ?? "#4B5563";
-  const borderColor = colorTwo ?? "#3C444F";
+
   const textColorClass = getTextColorBasedOnBg(backgroundColor);
   const [isMobile] = useMobile();
 
@@ -202,8 +203,9 @@ interface PHLRosterTableProps {
   roster: PHLPlayer[] | undefined;
   contracts?: PHLContract[] | null;
   ts: any;
-  colorOne?: string;
-  colorTwo?: string;
+  backgroundColor?: string;
+  headerColor?: string;
+  borderColor?: string;
   team?: any;
   category?: string;
   openModal: (action: ModalAction, player: PHLPlayer) => void;
@@ -213,14 +215,13 @@ export const PHLRosterTable: FC<PHLRosterTableProps> = ({
   roster = [],
   contracts,
   ts,
-  colorOne,
-  colorTwo,
+  backgroundColor,
+  headerColor,
+  borderColor,
   team,
   category,
   openModal,
 }) => {
-  const backgroundColor = colorOne ?? "#4B5563";
-  const borderColor = colorTwo ?? "#3C444F"; 
   const textColorClass = getTextColorBasedOnBg(backgroundColor);
   const [isMobile] = useMobile();
 
@@ -385,8 +386,9 @@ export const PHLRosterTable: FC<PHLRosterTableProps> = ({
 
 interface CFBRosterTableProps {
   roster: CFBPlayer[];
-  colorOne?: string;
-  colorTwo?: string;
+  backgroundColor?: string;
+  headerColor?: string;
+  borderColor?: string;
   team?: any;
   category?: string;
   openModal: (action: ModalAction, player: CFBPlayer) => void;
@@ -394,14 +396,13 @@ interface CFBRosterTableProps {
 
 export const CFBRosterTable: FC<CFBRosterTableProps> = ({
   roster,
-  colorOne,
-  colorTwo,
+  backgroundColor,
+  headerColor,
+  borderColor,
   team,
   category,
   openModal,
 }) => {
-  const backgroundColor = colorOne ?? "#4B5563";
-  const borderColor = colorTwo ?? "#3C444F"; 
   const textColorClass = getTextColorBasedOnBg(backgroundColor);
   const [isMobile] = useMobile();
 
@@ -576,8 +577,9 @@ interface NFLRosterTableProps {
   roster: NFLPlayer[];
   contracts?: NFLContract[] | null;
   ts: any;
-  colorOne?: string;
-  colorTwo?: string;
+  backgroundColor?: string;
+  headerColor?: string;
+  borderColor?: string;
   team?: any;
   category?: string;
   openModal: (action: ModalAction, player: NFLPlayer) => void;
@@ -587,14 +589,14 @@ export const NFLRosterTable: FC<NFLRosterTableProps> = ({
   roster,
   contracts,
   ts,
-  colorOne,
-  colorTwo,
+  backgroundColor,
+  headerColor,
+  borderColor,
   team,
   category,
   openModal,
 }) => {
-  const backgroundColor = colorOne ?? "#4B5563";
-  const borderColor = colorTwo ?? "#3C444F"; 
+
   const textColorClass = getTextColorBasedOnBg(backgroundColor);
   const [isMobile] = useMobile();
 
@@ -766,4 +768,3 @@ export const NFLRosterTable: FC<NFLRosterTableProps> = ({
     />
   );
 };
-


### PR DESCRIPTION
This PR relates to colour changes for the components i.e. removing the team colour heavy backgrounds in favor of a more universal colour scheme. There have also been some component changes namely to the team page and landing page.

- Background colour and borders changed for the following:
  - Landing page components and section cards
  - Table, and roster table components
- Team Overall grades reworked and displayed slightly differently.
  - They are now shown on the team page as well as the Landing page
  - Football will now also show special teams
- Dropdown on team page now shows text in white when searching for a team
- Stats component on landing page reworked so it's more proportioned. Text now more aligned, and player pictures larger but with max parameters added.
- Match up component on landing page reworked into a grid format so that the items stay more aligned for each team

Screenshots:

![image](https://github.com/user-attachments/assets/98a13d67-cfe6-43cc-934f-7b10180ace86)
![image](https://github.com/user-attachments/assets/74ff66e7-f487-4fc3-839b-24ac49befff4)
![image](https://github.com/user-attachments/assets/fb003c65-5a1f-4cf6-b0e5-26e4dfac08e9)
![image](https://github.com/user-attachments/assets/00b7b10d-62aa-4e8d-84df-8e4d0c1e949b)
![image](https://github.com/user-attachments/assets/5d1dfd86-f27c-4a5c-8d80-3653af01b2fe)
![image](https://github.com/user-attachments/assets/da390b4f-ce47-48ad-809a-924fbf5c29dc)

