### PR TITLE
Fix numerous NFL issues relating to player overalls and sorting

### DIFF
--- a/src/_design/Table.tsx
+++ b/src/_design/Table.tsx
@@ -10,6 +10,7 @@ import { getTextColorBasedOnBg } from "../_utility/getBorderClass";
 import { darkenColor } from "../_utility/getDarkerColor";
 import { Text } from "./Typography";
 import { isBrightColor } from "../_utility/isBrightColor";
+import { League, SimNFL } from "../_constants/constants";
 
 export interface SortState {
   key: string | null;
@@ -32,6 +33,7 @@ export interface TableProps<T> {
   rowRenderer: (item: T, index: number, backgroundColor: string) => ReactNode;
   rowBgColor?: string;
   darkerRowBgColor?: string;
+  league?: League;
 }
 
 export const Table = <T,>({
@@ -41,6 +43,7 @@ export const Table = <T,>({
   rowRenderer,
   rowBgColor,
   darkerRowBgColor,
+  league,
 }: TableProps<T>): JSX.Element => {
   let backgroundColor = "#1f2937";
   let borderColor = team?.ColorTwo || "#4B5563";
@@ -77,6 +80,11 @@ export const Table = <T,>({
     }
     const { key, order } = sortState;
     const sorted = [...data].sort((a: any, b: any) => {
+      if (league === SimNFL && key === "Overall") {
+        if (a.ShowLetterGrade && !b.ShowLetterGrade) return 1;
+        if (!a.ShowLetterGrade && b.ShowLetterGrade) return -1;
+      }
+
       if (a[key] < b[key]) return order === "asc" ? -1 : 1;
       if (a[key] > b[key]) return order === "asc" ? 1 : -1;
       return 0;

--- a/src/components/Common/Modals.tsx
+++ b/src/components/Common/Modals.tsx
@@ -31,6 +31,7 @@ import { HeightToFeetAndInches } from "../../_utility/getHeightByFeetAndInches";
 import { getYear } from "../../_utility/getYear";
 import { CheckCircle, CrossCircle } from "../../_design/Icons";
 import PlayerPicture from "../../_utility/usePlayerFaces";
+import { GetNFLOverall } from "../Team/TeamPageUtils";
 
 interface PlayerInfoModalBodyProps {
   league: League;
@@ -900,7 +901,9 @@ export const NFLPlayerInfoModalBody: FC<NFLPlayerInfoModalBodyProps> = ({
           Overall
         </Text>
         <Text variant="small" classes="whitespace-nowrap">
-          {player.Overall}
+          {player.ShowLetterGrade
+            ? GetNFLOverall(player.Overall, true)
+            : player.Overall}
         </Text>
       </div>
       <div className="flex flex-col">

--- a/src/components/Team/TeamPageTables.tsx
+++ b/src/components/Team/TeamPageTables.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../_constants/constants";
 import { SelectDropdown } from "../../_design/Select";
 import { CheckCircle, CrossCircle, ShieldCheck, User } from "../../_design/Icons";
+import { SimNFL } from "../../_constants/constants";
 
 interface CHLRosterTableProps {
   roster: CHLPlayer[];
@@ -605,7 +606,7 @@ export const NFLRosterTable: FC<NFLRosterTableProps> = ({
       { header: "Name", accessor: "LastName" },
       { header: "Pos", accessor: "Position" },
       { header: isMobile ? "Arch" : "Archetype", accessor: "Archetype" },
-      { header: "Exp", accessor: "Year" },
+      { header: "Exp", accessor: "Experience" },
       { header: "Ovr", accessor: "Overall" },
     ];
 
@@ -670,7 +671,11 @@ export const NFLRosterTable: FC<NFLRosterTableProps> = ({
   }, [isMobile, category]);
 
   const sortedRoster = useMemo(() => {
-    return [...roster].sort((a, b) => b.Overall - a.Overall);
+    return [...roster].sort((a, b) => {
+      if (a.ShowLetterGrade && !b.ShowLetterGrade) return 1;
+      if (!a.ShowLetterGrade && b.ShowLetterGrade) return -1;
+      return b.Overall - a.Overall;
+    });
   }, [roster]);
 
   const rowRenderer = (
@@ -765,6 +770,7 @@ export const NFLRosterTable: FC<NFLRosterTableProps> = ({
       rowRenderer={rowRenderer}
       backgroundColor={backgroundColor}
       team={team}
+      league={SimNFL}
     />
   );
 };


### PR DESCRIPTION
PR is a few hot fixes related to the NFL team page and player modal

- Player info modal card now reveals letter grade for NFL players that .showLettergrade is true
- NFL roster table now always has the unrevealed overall players at the bottom of the table regardless of sort
- NFL sort by Experience fixed