### PR TITLE
Fix width of game bar on desktop (landing page)

### DIFF
--- a/src/components/LandingPage/TeamLandingPageComponents.tsx
+++ b/src/components/LandingPage/TeamLandingPageComponents.tsx
@@ -153,7 +153,7 @@ export const GamesBar = ({
 
   return (
     <div className="flex pb-1">
-      <div className="flex w-[90vw] sm:w-full max-w-[1400px] justify-center">
+      <div className="flex w-[90vw] sm:w-full max-w-[1600px] justify-center">
         <div className="relative flex items-center w-[92vw] md:w-[72.6em] 3xl:w-full pb-1">
           <button
             onClick={scrollLeft}


### PR DESCRIPTION
This PR fixes the width of the game bar on landing page

![image](https://github.com/user-attachments/assets/66fb9ca6-e673-441a-a249-5552ab7c9bb7)
