### PR TITLE
View rejected free agency offers in PHL

### DIFF
--- a/src/_design/Icons.tsx
+++ b/src/_design/Icons.tsx
@@ -24,6 +24,7 @@ import {
   BellIcon,
   BellAlertIcon,
   ChatBubbleOvalLeftEllipsisIcon,
+  QuestionMarkCircleIcon,
 } from "@heroicons/react/16/solid";
 
 // 🔑 Define Props Interface for LockIcon
@@ -227,4 +228,8 @@ export const ChatBubble: React.FC<LockIconProps> = ({ textColorClass }) => {
 
 export const Close: React.FC<LockIconProps> = ({ textColorClass }) => {
   return <XCircleIcon className={`size-5 ${textColorClass}`} />;
+};
+
+export const QuestionMark: React.FC<LockIconProps> = ({ textColorClass }) => {
+  return <QuestionMarkCircleIcon className={`size-5 ${textColorClass}`} />;
 };

--- a/src/components/FreeAgencyPage/Common/OffersTable.tsx
+++ b/src/components/FreeAgencyPage/Common/OffersTable.tsx
@@ -27,7 +27,11 @@ import { getLogo } from "../../../_utility/getLogo";
 import { Table, TableCell } from "../../../_design/Table";
 import { Text } from "../../../_design/Typography";
 import { Button, ButtonGroup } from "../../../_design/Buttons";
-import { CrossCircle, CurrencyDollar } from "../../../_design/Icons";
+import {
+  CrossCircle,
+  CurrencyDollar,
+  QuestionMark,
+} from "../../../_design/Icons";
 import { Logo } from "../../../_design/Logo";
 import {
   getFACompetitivePreference,
@@ -82,6 +86,7 @@ export const OfferTable: FC<OfferTableProps> = ({
   const backgroundColor = colorOne;
   const rosterColumns = useMemo(() => {
     let columns = [
+      { header: "Team", accessor: "Team" },
       { header: "Name", accessor: "LastName" },
       { header: "Pos", accessor: "Position" },
       { header: !isDesktop ? "Arch" : "Archetype", accessor: "Archetype" },
@@ -175,6 +180,11 @@ export const OfferTable: FC<OfferTableProps> = ({
       offerIds = offers && offers.map((x) => x.TeamID);
       logos = offers && offerIds.map((id) => getLogo(SimPHL, id, false));
     }
+    let winningLogo = "FA";
+    let teamID = player.TeamID;
+    if (teamID > 0) {
+      winningLogo = getLogo(SimPHL, teamID, false);
+    }
 
     return (
       <div
@@ -182,6 +192,17 @@ export const OfferTable: FC<OfferTableProps> = ({
         className={`table-row border-b dark:border-gray-700 text-left`}
         style={{ backgroundColor }}
       >
+        <TableCell classes="w-[5em] min-[430px]:w-[4em]">
+          <div className="flex flex-row">
+            {player.TeamID > 0 ? (
+              <Logo url={winningLogo} variant="tiny" containerClass="p-2" />
+            ) : (
+              <div className="ml-2">
+                <QuestionMark />
+              </div>
+            )}
+          </div>
+        </TableCell>
         {attributes.map((attr, idx) => (
           <TableCell
             key={idx}
@@ -256,7 +277,7 @@ export const OfferTable: FC<OfferTableProps> = ({
             <Button
               variant="success"
               size="xs"
-              disabled={ts.IsFreeAgencyLocked}
+              disabled={ts.IsFreeAgencyLocked || item.IsRejected}
               onClick={() =>
                 handleOfferModal(FreeAgentOffer, player as PHLPlayer)
               }

--- a/src/components/FreeAgencyPage/PHLFreeAgency.tsx/usePHLFreeAgency.tsx
+++ b/src/components/FreeAgencyPage/PHLFreeAgency.tsx/usePHLFreeAgency.tsx
@@ -45,6 +45,7 @@ export const usePHLFreeAgency = () => {
     waiverOffers,
     proRosterMap,
     affiliatePlayers,
+    proPlayerMap,
   } = hkStore;
   const { isModalOpen, handleOpenModal, handleCloseModal } = useModal();
   const [freeAgencyCategory, setFreeAgencyCategory] = useState(Overview);
@@ -64,14 +65,6 @@ export const usePHLFreeAgency = () => {
   const freeAgents = useMemo(() => {
     return proRosterMap[0].filter((player) => player.IsFreeAgent);
   }, [proRosterMap]);
-
-  const freeAgentMap = useMemo(() => {
-    const dict: Record<number, ProfessionalPlayer> = {};
-    for (let i = 0; i < freeAgents.length; i++) {
-      dict[freeAgents[i].ID] = freeAgents[i];
-    }
-    return dict;
-  }, [freeAgents]);
 
   const waiverPlayers = useMemo(() => {
     return proRosterMap[0].filter((player) => player.IsWaived);
@@ -297,7 +290,7 @@ export const usePHLFreeAgency = () => {
     country,
     regionOptions,
     filteredFA,
-    freeAgentMap,
+    freeAgentMap: proPlayerMap,
     waiverPlayerMap,
     teamFreeAgentOffers,
     teamWaiverOffers,

--- a/src/context/SimHockeyContext.tsx
+++ b/src/context/SimHockeyContext.tsx
@@ -1007,7 +1007,6 @@ export const SimHCKProvider: React.FC<SimHCKProviderProps> = ({ children }) => {
         variant: "success",
         autoHideDuration: 3000,
       });
-      console.log({ res, dto });
       setFreeAgentOffers((prevOffers) => {
         const offers = [...prevOffers].filter((offer) => offer.ID !== dto.ID);
         return offers;

--- a/src/context/SimHockeyContext.tsx
+++ b/src/context/SimHockeyContext.tsx
@@ -1009,7 +1009,7 @@ export const SimHCKProvider: React.FC<SimHCKProviderProps> = ({ children }) => {
       });
       console.log({ res, dto });
       setFreeAgentOffers((prevOffers) => {
-        const offers = [...prevOffers].filter((offer) => offer.ID !== res.ID);
+        const offers = [...prevOffers].filter((offer) => offer.ID !== dto.ID);
         return offers;
       });
     }

--- a/src/context/SimHockeyContext.tsx
+++ b/src/context/SimHockeyContext.tsx
@@ -470,6 +470,13 @@ export const SimHCKProvider: React.FC<SimHCKProviderProps> = ({ children }) => {
         playerMap[p.ID] = p;
       }
     }
+    const freeAgents = proRosterMap[0];
+    if (freeAgents) {
+      for (let i = 0; i < freeAgents.length; i++) {
+        const p = freeAgents[i];
+        playerMap[p.ID] = p;
+      }
+    }
 
     return playerMap;
   }, [proRosterMap, phlTeams]);

--- a/src/models/hockeyModels.ts
+++ b/src/models/hockeyModels.ts
@@ -713,6 +713,7 @@ export class FreeAgencyOffer {
   ContractValue: number;
   BonusPercentage: number;
   IsActive: boolean;
+  IsRejected: boolean;
   Syncs: number;
   ToAffiliate: boolean;
 
@@ -740,6 +741,7 @@ export class FreeAgencyOffer {
     this.ContractValue = source["ContractValue"];
     this.BonusPercentage = source["BonusPercentage"];
     this.IsActive = source["IsActive"];
+    this.IsRejected = source["IsRejected"];
     this.Syncs = source["Syncs"];
     this.ToAffiliate = source["ToAffiliate"];
   }


### PR DESCRIPTION
- Free Agency sync for PHL will now reject offers rather than deactivate them if a team selects a different offer during sync.
- Teams signing a player in FA will have their logo displayed on the left side of the offer table.
- Teams will be able to view their rejected offers in Free Agency after a sync occurs.
- Teams *cannot* place an offer on a rejected contract but may use the Cross button to official remove the contract from view.
- Fixed a bug where a cancelled offer wasn't filtered out.
![image](https://github.com/user-attachments/assets/d1ce027b-487e-4225-a2a8-d50a64f11d64)
