### PR TITLE
Add more post calls for SimFBA & context

### DIFF
--- a/src/_services/collegePollService.tsx
+++ b/src/_services/collegePollService.tsx
@@ -1,9 +1,29 @@
-import { hckUrl } from "../_constants/urls";
-import { PostCall } from "../_helper/fetchHelper";
+import { fbaUrl, hckUrl } from "../_constants/urls";
+import { GetCall, PostCall } from "../_helper/fetchHelper";
 import { CollegePollSubmission as HCKPollSubmission } from "../models/hockeyModels";
+import { 
+  CollegePollSubmission as FBAPollSubmission, 
+  PollDataResponse as FBAPollDataResponse 
+} from "../models/footballModels";
 
 export const CollegePollService = {
   HCKSubmitPoll: async (dto: any): Promise<HCKPollSubmission> => {
     return await PostCall(`${hckUrl}college/poll/create/`, dto);
+  },
+
+  FBAGetTeamDataForPollForm: async (): Promise<FBAPollDataResponse> => {
+    return await GetCall(`${fbaUrl}college/poll/page/`);
+  },
+
+  FBAGetSubmittedPoll: async (): Promise<FBAPollSubmission> => {
+    return await GetCall(`${fbaUrl}college/poll/get/`);
+  },
+
+  FBAGetOfficialPollData: async (): Promise<FBAPollDataResponse> => {
+    return await GetCall(`${fbaUrl}college/poll/official/`);
+  },
+
+  FBASubmitPoll: async (dto: FBAPollSubmission): Promise<FBAPollSubmission> => {
+    return await PostCall(`${fbaUrl}college/poll/submit/`, dto);
   },
 };

--- a/src/_services/depthChartService.tsx
+++ b/src/_services/depthChartService.tsx
@@ -1,0 +1,14 @@
+import { fbaUrl } from "../_constants/urls";
+import { PostCall, GetCall, PUTCall } from "../_helper/fetchHelper";
+
+export const DepthChartService = {
+
+  SaveCFBDepthChart: async (dto: any): Promise<void> => {
+    await PUTCall(`${fbaUrl}gameplan/college/updatedepthchart`, dto);
+  },
+
+  SaveNFLDepthChart: async (dto: any): Promise<void> => {
+    await PostCall(`${fbaUrl}gameplan/nfl/updatedepthchart`, dto);
+  },
+};
+

--- a/src/_services/draftService.tsx
+++ b/src/_services/draftService.tsx
@@ -1,0 +1,24 @@
+import { fbaUrl, bbaUrl, hckUrl } from "../_constants/urls";
+import { GetCall, PostCall, GetActionCall } from "../_helper/fetchHelper";
+
+export const DraftService = {
+  CreateNFLScoutingProfile: async (dto: any): Promise<any> => {
+    return await PostCall(`${fbaUrl}nfl/draft/create/scoutprofile`, dto);
+  },
+
+  RevealNFLAttribute: async (dto: any): Promise<any> => {
+    return await PostCall(`${fbaUrl}nfl/draft/reveal/attribute`, dto);
+  },
+
+  RemoveNFLPlayerFromBoard: async (id: number): Promise<void> => {
+    await GetActionCall(`${fbaUrl}nfl/draft/remove/${id}`);
+  },
+
+  DraftNFLPlayer: async (dto: any): Promise<any> => {
+    return await PostCall(`${fbaUrl}nfl/draft/player/`, dto);
+  },
+
+  ExportNFLPlayers: async (dto: any): Promise<any> => {
+    return await PostCall(`${fbaUrl}nfl/draft/export/picks`, dto);
+  },
+};

--- a/src/_services/freeAgencyService.tsx
+++ b/src/_services/freeAgencyService.tsx
@@ -1,4 +1,4 @@
-import { bbaUrl, hckUrl } from "../_constants/urls";
+import { fbaUrl, bbaUrl, hckUrl } from "../_constants/urls";
 import { PostCall } from "../_helper/fetchHelper";
 import {
   NBAContractOffer,
@@ -12,6 +12,12 @@ import {
   WaiverOffer,
   WaiverOfferDTO,
 } from "../models/hockeyModels";
+import {
+  FreeAgencyOffer as NFLFreeAgencyOffer,
+  FreeAgencyOfferDTO as NFLFreeAgencyOfferDTO,
+  NFLWaiverOffer,
+  NFLWaiverOffDTO
+} from "../models/footballModels"
 
 export const FreeAgencyService = {
   HCKSaveFreeAgencyOffer: async (
@@ -58,5 +64,29 @@ export const FreeAgencyService = {
     dto: NBAWaiverOfferDTO
   ): Promise<WaiverOffer> => {
     return await PostCall(`${bbaUrl}nba/waiverwire/cancel/offer`, dto);
+  },
+
+  FBASaveFreeAgencyOffer: async (
+    dto: NFLFreeAgencyOfferDTO
+  ): Promise<NFLFreeAgencyOffer> => {
+    return await PostCall(`${fbaUrl}nfl/freeagency/create/offer`, dto);
+  },
+
+  FBACancelFreeAgencyOffer: async (
+    dto: NFLFreeAgencyOfferDTO
+  ): Promise<NFLFreeAgencyOffer> => {
+    return await PostCall(`${fbaUrl}nfl/freeagency/cancel/offer`, dto);
+  },
+
+  FBASaveWaiverWireOffer: async (
+    dto: NFLWaiverOffDTO
+  ): Promise<NFLWaiverOffer> => {
+    return await PostCall(`${fbaUrl}nfl/waiverwire/create/offer`, dto);
+  },
+
+  FBACancelWaiverWireOffer: async (
+    dto: NFLWaiverOffDTO
+  ): Promise<NFLWaiverOffer> => {
+    return await PostCall(`${fbaUrl}nfl/waiverwire/cancel/offer`, dto);
   },
 };

--- a/src/_services/gameplanService.tsx
+++ b/src/_services/gameplanService.tsx
@@ -1,5 +1,5 @@
-import { bbaUrl, hckUrl } from "../_constants/urls";
-import { PostCall } from "../_helper/fetchHelper";
+import { fbaUrl, bbaUrl, hckUrl } from "../_constants/urls";
+import { PostCall, GetCall } from "../_helper/fetchHelper";
 
 export const GameplanService = {
   SaveCHLGameplan: async (dto: any): Promise<void> => {
@@ -24,5 +24,13 @@ export const GameplanService = {
 
   SaveNBAGameplan: async (dto: any): Promise<void> => {
     await PostCall(`${bbaUrl}nba/gameplans/update`, dto);
+  },
+
+  SaveCFBGameplan: async (dto: any): Promise<void> => {
+    await PostCall(`${fbaUrl}gameplan/college/updategameplan`, dto);
+  },
+
+  SaveNFLGameplan: async (dto: any): Promise<void> => {
+    await PostCall(`${fbaUrl}gameplan/nfl/updategameplan`, dto);
   },
 };

--- a/src/_services/recruitService.tsx
+++ b/src/_services/recruitService.tsx
@@ -1,5 +1,5 @@
-import { bbaUrl, hckUrl } from "../_constants/urls";
-import { GetExportCall, PostCall } from "../_helper/fetchHelper";
+import { fbaUrl, bbaUrl, hckUrl } from "../_constants/urls";
+import { GetExportCall, PostCall, PUTCall } from "../_helper/fetchHelper";
 import {
   PlayerRecruitProfile as BBAPlayerRecruitProfile,
   UpdateRecruitingBoardDto as BBAUpdateRecruitingBoardDto,
@@ -9,6 +9,10 @@ import {
   UpdateRecruitingBoardDTO as HCKUpdateRecruitingBoardDTO,
   UpdateRecruitProfileDto as HCKUpdateRecruitProfileDto,
 } from "../models/hockeyModels";
+import {
+  RecruitPlayerProfile as FBARecruitPlayerProfile,
+  UpdateRecruitingBoardDTO as FBAUpdateRecruitingBoardDTO,
+} from "../models/footballModels";
 
 export const RecruitService = {
   HCKCreateRecruitProfile: async (
@@ -71,5 +75,35 @@ export const RecruitService = {
 
   ExportCHLRecruits: async () => {
     await GetExportCall(`${hckUrl}export/college/recruits/all`, "blob");
+  },
+
+  FBACreateRecruitProfile: async (
+    dto: any
+  ): Promise<FBARecruitPlayerProfile> => {
+    return await PostCall(`${fbaUrl}recruiting/addrecruit/`, dto);
+  },
+
+  FBAToggleScholarship: async (dto: any): Promise<FBARecruitPlayerProfile> => {
+    return await PostCall(`${fbaUrl}recruiting/toggleScholarship/`, dto);
+  },
+
+  FBARemovePlayerFromBoard: async (
+    dto: any
+  ): Promise<FBARecruitPlayerProfile> => {
+    return await PUTCall(`${fbaUrl}recruiting/removecrootfromboard/`, dto);
+  },
+
+  FBASaveRecruitingBoard: async (
+    dto: any
+  ): Promise<FBAUpdateRecruitingBoardDTO> => {
+    return await PostCall(`${fbaUrl}recruiting/savecrootboard/`, dto);
+  },
+
+  FBAToggleAIBehavior: async (dto: any): Promise<FBAUpdateRecruitingBoardDTO> => {
+    return await PostCall(`${fbaUrl}recruiting/save/ai/`, dto);
+  },
+
+  ExportCFBCroots: async () => {
+    await GetExportCall(`${fbaUrl}recruits/export/all/`, "blob");
   },
 };

--- a/src/_services/tradeService.tsx
+++ b/src/_services/tradeService.tsx
@@ -1,6 +1,7 @@
-import { hckUrl } from "../_constants/urls";
+import { fbaUrl, hckUrl, bbaUrl } from "../_constants/urls";
 import { GetActionCall, GetCall, PostCall } from "../_helper/fetchHelper";
 import { TradePreferences, TradeProposal } from "../models/hockeyModels";
+import { NFLTradePreferences, NFLTradeProposalDTO } from "../models/footballModels";
 
 export const TradeService = {
   HCKUpdateTradePreferences: async (dto: TradePreferences): Promise<void> => {
@@ -33,5 +34,61 @@ export const TradeService = {
 
   HCKCleanupRejectedTrades: async (): Promise<void> => {
     await GetActionCall(`${hckUrl}trades/admin/cleanup`);
+  },
+
+  FBAGetTradeBlockData: async (teamId: number): Promise<any> => {
+    return await GetCall(`${fbaUrl}trades/nfl/block/${teamId}`);
+  },
+
+  FBAPlacePlayerOnTradeBlock: async (playerId: number): Promise<void> => {
+    await GetActionCall(`${fbaUrl}trades/nfl/place/block/${playerId}`);
+  },
+
+  FBAUpdateTradePreferences: async (dto: NFLTradePreferences): Promise<void> => {
+    await PostCall(`${fbaUrl}trades/nfl/preferences/update`, dto);
+  },
+
+  FBACreateTradeProposal: async (dto: NFLTradeProposalDTO): Promise<void> => {
+    await PostCall(`${fbaUrl}trades/nfl/create/proposal`, dto);
+  },
+
+  FBAProcessDraftTrade: async (dto: any): Promise<void> => {
+    await PostCall(`${fbaUrl}trades/nfl/draft/process`, dto);
+  },
+
+  FBAAcceptTradeProposal: async (proposalId: number): Promise<void> => {
+    await GetActionCall(`${fbaUrl}trades/nfl/proposal/accept/${proposalId}`);
+  },
+
+  FBARejectTradeProposal: async (proposalId: number): Promise<void> => {
+    await GetActionCall(`${fbaUrl}trades/nfl/proposal/reject/${proposalId}`);
+  },
+
+  FBACancelTradeProposal: async (proposalId: number): Promise<void> => {
+    await GetActionCall(`${fbaUrl}trades/nfl/proposal/cancel/${proposalId}`);
+  },
+
+  FBAGetAllAcceptedTrades: async (): Promise<any> => {
+    return await GetCall(`${fbaUrl}trades/nfl/all/accepted`);
+  },
+
+  FBAGetAllRejectedTrades: async (): Promise<any> => {
+    return await GetCall(`${fbaUrl}trades/nfl/all/rejected`);
+  },
+
+  FBAConfirmAcceptedTrade: async (proposalId: number): Promise<void> => {
+    await GetActionCall(`${fbaUrl}admin/trades/accept/sync/${proposalId}`);
+  },
+
+  FBAVetoAcceptedTrade: async (proposalId: number): Promise<void> => {
+    await GetActionCall(`${fbaUrl}admin/trades/veto/sync/${proposalId}`);
+  },
+
+  FBACleanupRejectedTrades: async (): Promise<void> => {
+    await GetActionCall(`${fbaUrl}admin/trades/cleanup`);
+  },
+
+  FBARegenerateCapsheets: async (): Promise<void> => {
+    await GetActionCall(`${fbaUrl}nfl/capsheet/generate`);
   },
 };

--- a/src/context/SimFBAContext.tsx
+++ b/src/context/SimFBAContext.tsx
@@ -9,6 +9,8 @@ import {
 } from "react";
 import { useAuthStore } from "./AuthContext";
 import { BootstrapService } from "../_services/bootstrapService";
+import { DepthChartService } from "../_services/depthChartService";
+import { GameplanService } from "../_services/gameplanService";
 import {
   CollegeGame,
   CollegePlayer,
@@ -99,6 +101,10 @@ interface SimFBAContextProps {
   redshirtPlayer: (playerID: number, teamID: number) => Promise<void>;
   promisePlayer: (playerID: number, teamID: number) => Promise<void>;
   updateCFBRosterMap: (newMap: Record<number, CollegePlayer[]>) => void;
+  saveCFBDepthChart: (dto: any) => Promise<void>;
+  saveNFLDepthChart: (dto: any) => Promise<void>;
+  saveCFBGameplan: (dto: any) => Promise<void>;
+  saveNFLGameplan: (dto: any) => Promise<void>;
   playerFaces: {
     [key: number]: FaceDataResponse;
   };
@@ -163,6 +169,10 @@ const defaultContext: SimFBAContextProps = {
   redshirtPlayer: async () => {},
   promisePlayer: async () => {},
   updateCFBRosterMap: () => {},
+  saveCFBDepthChart: async () => {},
+  saveNFLDepthChart: async () => {},
+  saveCFBGameplan: async () => {},
+  saveNFLGameplan: async () => {},
   playerFaces: {},
   proContractMap: {},
   proExtensionMap: {},
@@ -582,6 +592,38 @@ export const SimFBAProvider: React.FC<SimFBAProviderProps> = ({ children }) => {
     setCFBRosterMap(newMap);
   };
 
+  const saveCFBDepthChart = async (dto: any) => {
+    await DepthChartService.SaveCFBDepthChart(dto);
+    enqueueSnackbar("Depth Chart saved!", {
+      variant: "success",
+      autoHideDuration: 3000,
+    });
+  };
+
+  const saveNFLDepthChart = async (dto: any) => {
+    await DepthChartService.SaveNFLDepthChart(dto);
+    enqueueSnackbar("Depth Chart saved!", {
+      variant: "success",
+      autoHideDuration: 3000,
+    });
+  };
+
+  const saveCFBGameplan = async (dto: any) => {
+    const res = await GameplanService.SaveCFBGameplan(dto);
+    enqueueSnackbar("Gameplan saved!", {
+      variant: "success",
+      autoHideDuration: 3000,
+    });
+  };
+
+  const saveNFLGameplan = async (dto: any) => {
+    const res = await GameplanService.SaveNFLGameplan(dto);
+    enqueueSnackbar("Gameplan saved!", {
+      variant: "success",
+      autoHideDuration: 3000,
+    });
+  };
+
   return (
     <SimFBAContext.Provider
       value={{
@@ -638,6 +680,10 @@ export const SimFBAProvider: React.FC<SimFBAProviderProps> = ({ children }) => {
         promisePlayer,
         cutNFLPlayer,
         updateCFBRosterMap,
+        saveCFBDepthChart,
+        saveNFLDepthChart,
+        saveCFBGameplan,
+        saveNFLGameplan,
         playerFaces,
         proContractMap,
         proExtensionMap,


### PR DESCRIPTION
This PR relates to some more SimFBA calls and services being added to 2.0 and also context added for gameplan and depth chart. Below added are all relating to football:

- depthChartService.tsx created, relates strictly to CFB and NFL. Also added to context.
- gameplanService.tsx updated to add football and added to context.
- draftService.tsx created, FBA calls added
- Waiver and FA offers added to freeAgencyService.tsx
- College poll calls added to collegePollService.tsx
- Trade calls added to tradeService.tsx
- Recruiting calls added to recruitService.tsx

For reference, I used 1.0 and the existing calls for other sports a baseline for these.