### PR TITLE
Move facedata, fix redshirt bug

### DIFF
--- a/src/context/SimBBAContext.tsx
+++ b/src/context/SimBBAContext.tsx
@@ -642,7 +642,7 @@ export const SimBBAProvider: React.FC<SimBBAProviderProps> = ({ children }) => {
   );
   const redshirtPlayer = useCallback(
     async (playerID: number, teamID: number) => {
-      const res = await PlayerService.CutCBBPlayer(playerID);
+      const res = await PlayerService.RedshirtCBBPlayer(playerID);
       const rosterMap = { ...cbbRosterMap };
       const playerIDX = rosterMap[teamID].findIndex(
         (player) => player.ID === playerID

--- a/src/context/SimFBAContext.tsx
+++ b/src/context/SimFBAContext.tsx
@@ -589,7 +589,7 @@ export const SimFBAProvider: React.FC<SimFBAProviderProps> = ({ children }) => {
         );
         return;
       }
-      const res = await PlayerService.CutCFBPlayer(playerID);
+      const res = await PlayerService.RedshirtCFBPlayer(playerID);
       const playerIDX = rosterMap[teamID].findIndex(
         (player) => player.ID === playerID
       );

--- a/src/context/SimFBAContext.tsx
+++ b/src/context/SimFBAContext.tsx
@@ -436,7 +436,6 @@ export const SimFBAProvider: React.FC<SimFBAProviderProps> = ({ children }) => {
       setProNotifications(res.ProNotifications);
     }
 
-    setPlayerFaces(res.FaceData);
     setIsLoading(false);
   };
 
@@ -544,6 +543,7 @@ export const SimFBAProvider: React.FC<SimFBAProviderProps> = ({ children }) => {
       setProExtensionMap(res.ExtensionMap);
     }
 
+    setPlayerFaces(res.FaceData);
     setIsLoadingThree(false);
   };
 


### PR DESCRIPTION
This moves the setPlayerFaces call from Bootstrap 1 to Bootstrap 3 to align with the performance changes present in [this PR](https://github.com/CalebRose/SimFBA/pull/10) of the football API. It also fixes a couple of bugs where attempting to redshirt players would cut them instead.

Without the changes in the linked API PR, this will cause the interface to crash if opening a player card!