### PR TITLE
FormationView by formation

### DIFF
--- a/src/_design/Icons.tsx
+++ b/src/_design/Icons.tsx
@@ -27,7 +27,9 @@ import {
   ChatBubbleOvalLeftEllipsisIcon,
   QuestionMarkCircleIcon,
   TrophyIcon,
-  ArrowDownIcon
+  ArrowDownIcon,
+  ArrowRightIcon,
+  ArrowLeftIcon
 } from "@heroicons/react/16/solid";
 import { GiDiamondTrophy, GiTrophyCup, GiRibbonMedal, GiTrophy, GiShieldBash, GiShield, GiSoccerKick, GiAmericanFootballPlayer, GiTicTacToe } from "react-icons/gi";
 import { IoIosRibbon } from "react-icons/io";
@@ -288,5 +290,13 @@ export const TicTacToe: React.FC<LockIconProps> = ({ textColorClass }) => {
 
 export const ArrowDown: React.FC<LockIconProps> = ({ textColorClass }) => {
   return <ArrowDownIcon className={`size-5 ${textColorClass}`} />;
+};
+
+export const ArrowRight: React.FC<LockIconProps> = ({ textColorClass }) => {
+  return <ArrowRightIcon className={`size-5 ${textColorClass}`} />;
+};
+
+export const ArrowLeft: React.FC<LockIconProps> = ({ textColorClass }) => {
+  return <ArrowLeftIcon className={`size-5 ${textColorClass}`} />;
 };
 

--- a/src/components/Gameplan/FootballGameplan/Common/BackupPlayerCard.tsx
+++ b/src/components/Gameplan/FootballGameplan/Common/BackupPlayerCard.tsx
@@ -85,7 +85,7 @@ const BackupPlayerCard: React.FC<BackupPlayerCardProps> = ({
           style={generateBackgroundPattern(accentColor)}
         />
         <div 
-          className="absolute top-0 left-0 px-1 rounded-br-sm z-10"
+          className="absolute top-0 left-0 px-1 rounded-br-md z-10"
           style={{ backgroundColor: 'rgba(0,0,0,0.8)' }}
         >
           <Text 

--- a/src/components/Gameplan/FootballGameplan/Common/BackupPlayerCard.tsx
+++ b/src/components/Gameplan/FootballGameplan/Common/BackupPlayerCard.tsx
@@ -10,6 +10,8 @@ import { generateSimpleBackgroundPattern, generateCardGradient } from '../Utils/
 import { getRatingColor } from '../Utils/UIUtils';
 import { CARD_CLASSES, TRANSITIONS } from '../Constants/UIConstants';
 import RatingBadge from './RatingBadge';
+import { generateBackgroundPattern } from '../Utils/ComponentStyleUtils';
+import { getTextSize } from '../Utils/ComponentStyleUtils';
 
 interface BackupPlayerCardProps {
   player: CollegePlayer | NFLPlayer | null | undefined;
@@ -48,6 +50,10 @@ const BackupPlayerCard: React.FC<BackupPlayerCardProps> = ({
             background: 'linear-gradient(135deg, #374151 0%, #4B5563 100%)',
           }}
         >
+          <div 
+            className="absolute inset-0 opacity-10"
+            style={generateBackgroundPattern(accentColor)}
+          />
           <div className="flex items-center justify-center h-full">
             <Text variant="xs" classes="text-gray-400 text-center text-[10px]">
               No Player
@@ -75,12 +81,16 @@ const BackupPlayerCard: React.FC<BackupPlayerCardProps> = ({
         }}
       >
         <div 
+          className="absolute inset-0 opacity-10"
+          style={generateBackgroundPattern(accentColor)}
+        />
+        <div 
           className="absolute top-0 left-0 px-1 rounded-br-sm z-10"
-          style={{ backgroundColor: accentColor }}
+          style={{ backgroundColor: 'rgba(0,0,0,0.8)' }}
         >
           <Text 
-            variant="xs" 
-            classes={`font-bold text-[10px] ${getTextColorBasedOnBg(accentColor)}`}
+            variant={getTextSize("md")} 
+            classes={`font-bold ${getTextColorBasedOnBg(accentColor)}`}
           >
             {positionLevel}
           </Text>

--- a/src/components/Gameplan/FootballGameplan/Common/DepthChartCard.tsx
+++ b/src/components/Gameplan/FootballGameplan/Common/DepthChartCard.tsx
@@ -10,11 +10,13 @@ import {
   getSizeClasses, 
   getTextSize, 
   getPictureSize, 
-  generateBackgroundPattern, 
-  generateCardGradient 
+  getBackgroundPattern,
+  generateCardGradient,
+  BackgroundPatternType
 } from '../Utils/ComponentStyleUtils';
 import { getRatingColor } from '../Utils/UIUtils';
 import { getYear } from '../../../../_utility/getYear';
+import { isBrightColor } from '../../../../_utility/isBrightColor';
 
 interface DepthChartCardProps {
   player: any;
@@ -27,6 +29,7 @@ interface DepthChartCardProps {
   category?: string;
   depthChartManager?: boolean;
   innerBackgroundColor?: string;
+  backgroundPattern?: BackgroundPatternType;
 }
 
 export const DepthChartCard: React.FC<DepthChartCardProps> = ({
@@ -39,7 +42,8 @@ export const DepthChartCard: React.FC<DepthChartCardProps> = ({
   category,
   depthChartManager,
   innerBackgroundColor,
-  position
+  position,
+  backgroundPattern = 'texture'
 }) => {
   const teamColors = useTeamColors(team?.ColorOne, team?.ColorTwo, team?.ColorThree);
   const backgroundColor = teamColors.One;
@@ -49,6 +53,7 @@ export const DepthChartCard: React.FC<DepthChartCardProps> = ({
   const sizeClasses = getSizeClasses(size, 'depthChart');
   const pictureSize = getPictureSize(size, true);
   const overallRating = getPlayerOverallRating(player, league, showLetterGrade);
+  const patternBg = isBrightColor(backgroundColor) ? "#000000" : "#FFFFFF";
 
   if (!player) {
     return (
@@ -91,7 +96,7 @@ export const DepthChartCard: React.FC<DepthChartCardProps> = ({
       >
         <div 
           className="absolute inset-0 opacity-10"
-          style={generateBackgroundPattern(accentColor)}
+          style={getBackgroundPattern(backgroundPattern, patternBg)}
         />
       {category === ManagementCard && (
         <div 

--- a/src/components/Gameplan/FootballGameplan/Constants/DepthChartConstants.ts
+++ b/src/components/Gameplan/FootballGameplan/Constants/DepthChartConstants.ts
@@ -134,6 +134,7 @@ export const FLEXBONE_GUN = 'flexbone-gun';
 export const WING_SPLIT_BACK_GUN = 'wing-split-back-gun';
 export const DOUBLE_WING_SPLIT = 'double-wing-split';
 export const DOUBLE_WING = 'double-wing';
+export const SINGLEBACK = 'singleback';
 
 export const FOUR_THREE_BASE = '4-3-base';
 export const FOUR_THREE_OVER = '4-3-over';
@@ -194,6 +195,7 @@ export const POSITION_PREFIXES = {
 
 export const FORMATION_KEYWORDS = {
   GUN: 'gun',
+  SINGLEBACK: 'singleback',
   PISTOL: 'pistol',
   SPREAD: 'spread',
   EMPTY: 'empty',

--- a/src/components/Gameplan/FootballGameplan/Constants/DepthChartConstants.ts
+++ b/src/components/Gameplan/FootballGameplan/Constants/DepthChartConstants.ts
@@ -122,3 +122,129 @@ export const SPECIAL_POSITION_SORTING = {
   KR: 'Speed',
   STU: 'Strength'
 } as const;
+
+export const UNDER_CENTER = 'under-center';
+export const GUN = 'gun';
+export const PISTOL = 'pistol';
+export const SPREAD = 'spread';
+export const TIGHT = 'tight';
+export const WING = 'wing';
+export const EMPTY = 'empty';
+export const FLEXBONE_GUN = 'flexbone-gun';
+export const WING_SPLIT_BACK_GUN = 'wing-split-back-gun';
+export const DOUBLE_WING_SPLIT = 'double-wing-split';
+export const DOUBLE_WING = 'double-wing';
+
+export const FOUR_THREE_BASE = '4-3-base';
+export const FOUR_THREE_OVER = '4-3-over';
+export const FOUR_THREE_UNDER = '4-3-under';
+export const FOUR_THREE_LIGHT = '4-3-light';
+export const FOUR_THREE_HEAVY = '4-3-heavy';
+export const THREE_FOUR_BASE = '3-4-base';
+export const THREE_FOUR_OVER = '3-4-over';
+export const THREE_FOUR_UNDER = '3-4-under';
+export const THREE_FOUR_OKIE = '3-4-okie';
+export const THREE_FOUR_BRONCO = '3-4-bronco';
+export const THREE_FOUR_EAGLE = '3-4-eagle';
+export const THREE_FOUR_FOUR_HEAVY = '3-4-4-heavy';
+export const FOUR_FOUR_BASE = '4-4-base';
+export const FOUR_FOUR_OVER = '4-4-over';
+export const FOUR_FOUR_UNDER = '4-4-under';
+export const FOUR_FOUR_JUMBO = '4-4-jumbo';
+export const FOUR_FOUR_HEAVY = '4-4-heavy';
+export const FOUR_TWO_FIVE_BASE = '4-2-5-base';
+export const FOUR_TWO_FIVE_NICKEL = '4-2-5-nickel';
+export const THREE_THREE_FIVE_BASE = '3-3-5-base';
+export const THREE_THREE_FIVE_OVER = '3-3-5-over';
+export const THREE_THREE_FIVE_NICKEL = '3-3-5-nickel';
+export const DIME_FOUR_ONE_SIX = 'dime-4-1-6';
+export const DIME_THREE_TWO_SIX = 'dime-3-2-6';
+export const FOUR_ONE_SIX_DIME = '4-1-6-dime';
+export const FOUR_ONE_SIX_BIG_DIME = '4-1-6-big-dime';
+export const THREE_TWO_SIX_DIME = '3-2-6-dime';
+export const THREE_TWO_SIX_BIG_PENNY = '3-2-6-big-penny';
+export const THREE_TWO_SIX_PENNY = '3-2-6-penny';
+export const QUARTER = 'quarter';
+export const GOAL_LINE = 'goal-line';
+
+export const POSITION_PREFIXES = {
+  QB: 'QB',
+  WR: 'WR',
+  TE: 'TE',
+  RB: 'RB',
+  FB: 'FB',
+  LT: 'LT',
+  LG: 'LG',
+  C: 'C',
+  RG: 'RG',
+  RT: 'RT',
+  RE: 'RE',
+  DT: 'DT',
+  LE: 'LE',
+  DE: 'DE',
+  LOLB: 'LOLB',
+  MLB: 'MLB',
+  ROLB: 'ROLB',
+  OLB: 'OLB',
+  ILB: 'ILB',
+  CB: 'CB',
+  FS: 'FS',
+  SS: 'SS'
+} as const;
+
+export const FORMATION_KEYWORDS = {
+  GUN: 'gun',
+  PISTOL: 'pistol',
+  SPREAD: 'spread',
+  EMPTY: 'empty',
+  TIGHT: 'tight',
+  WING: 'wing',
+  DOUBLE: 'double',
+  FLEXBONE: 'flexbone',
+  HEAVY: 'heavy',
+  LIGHT: 'light',
+  OVER: 'over',
+  UNDER: 'under',
+  BASE: 'base',
+  NICKEL: 'nickel',
+  DIME: 'dime',
+  QUARTER: 'quarter',
+  GOAL: 'goal',
+  LINE: 'line',
+  SPLIT: 'split',
+  BACK: 'back',
+  OKIE: 'okie',
+  BRONCO: 'bronco',
+  EAGLE: 'eagle',
+  JUMBO: 'jumbo',
+  BIG: 'big',
+  PENNY: 'penny'
+} as const;
+
+export const GRID_POSITIONS = {
+  COLUMNS: {
+    1: 1,
+    2: 2,
+    3: 3,
+    4: 4,
+    5: 5,
+    6: 6,
+    7: 7,
+    8: 8,
+    9: 9,
+    10: 10,
+    11: 11,
+    12: 12,
+    13: 13
+  },
+  ROWS: {
+    2: 2,
+    3: 3,
+    4: 4,
+    5: 5,
+    6: 6,
+    7: 7,
+    8: 8,
+    9: 9
+  }
+} as const;

--- a/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartManager.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartManager.tsx
@@ -4,6 +4,8 @@ import { SimCFB, SimNFL } from '../../../../_constants/constants';
 import { Text } from '../../../../_design/Typography';
 import { Button, ButtonGroup } from '../../../../_design/Buttons';
 import { useModal } from '../../../../_hooks/useModal';
+import { Modal } from '../../../../_design/Modal';
+import { CFBPlayerInfoModalBody, NFLDepthChartInfoModalBody } from '../../../Common/Modals';
 import { 
   POSITION_LIMITS, 
   OFFENSIVE_POSITIONS, 
@@ -62,6 +64,8 @@ const DepthChartManager: React.FC<DepthChartManagerProps> = ({
   const [selectedGroup, setSelectedGroup] = useState<'OFF' | 'DEF' | 'ST'>('OFF');
   const [modalPosition, setModalPosition] = useState<string>('');
   const { isModalOpen, handleOpenModal, handleCloseModal } = useModal();
+  const [modalPlayer, setModalPlayer] = useState<CollegePlayer | NFLPlayer | null>(null);
+  const { isModalOpen: isPlayerModalOpen, handleOpenModal: handleOpenPlayerModal, handleCloseModal: handleClosePlayerModal } = useModal();
   const getAssignedPlayersForPosition = (position: string) => {
     if (!depthChart?.DepthChartPlayers) return [];
 
@@ -109,6 +113,11 @@ const DepthChartManager: React.FC<DepthChartManagerProps> = ({
     handleOpenModal();
   };
 
+  const openModal = (player: CollegePlayer | NFLPlayer) => {
+    handleOpenPlayerModal();
+    setModalPlayer(player);
+  };
+
   const renderSelectedPosition = () => {
     const assignedPlayers = getAssignedPlayersForPosition(selectedPosition);
     const limit = POSITION_LIMITS[selectedPosition as keyof typeof POSITION_LIMITS];
@@ -137,7 +146,7 @@ const DepthChartManager: React.FC<DepthChartManagerProps> = ({
             const positionLevel = index + 1;
             const assignedPlayer = assignedPlayers.find((p: any) => parseInt(p.PositionLevel) === positionLevel);
             
-            let assignedPlayerOverall = 'N/A';
+            let assignedPlayerOverall;
             let assignedPlayerBackground = 'bg-gray-500';
             
             if (assignedPlayer?.playerData) {
@@ -165,9 +174,20 @@ const DepthChartManager: React.FC<DepthChartManagerProps> = ({
                       <Text variant="body-small" classes="text-white">
                         {assignedPlayer.playerData.Archetype} {assignedPlayer.playerData.Position}{assignedPlayer.playerData.PositionTwo ? `/${assignedPlayer.playerData.PositionTwo}` : ''}
                       </Text>
-                      <Text variant="body-small" classes="text-white font-semibold">
-                        {assignedPlayer.playerData.FirstName} {assignedPlayer.playerData.LastName}
-                      </Text>
+                      <div
+                        className="cursor-pointer hover:text-blue-400 transition-colors"
+                        onClick={() => openModal(assignedPlayer.playerData)}
+                        onMouseEnter={(e: React.MouseEvent<HTMLSpanElement>) => {
+                          (e.target as HTMLElement).style.color = "#fcd53f";
+                        }}
+                        onMouseLeave={(e: React.MouseEvent<HTMLSpanElement>) => {
+                          (e.target as HTMLElement).style.color = "";
+                        }}
+                      >
+                        <Text variant="body-small" classes="text-white font-semibold">
+                          {assignedPlayer.playerData.FirstName} {assignedPlayer.playerData.LastName}
+                        </Text>
+                      </div>
                     </div>
                     <div className="ml-auto">
                       <div 
@@ -365,6 +385,31 @@ const DepthChartManager: React.FC<DepthChartManagerProps> = ({
         onPlayerMove={onPlayerMove}
         onPlayerSwap={onPlayerSwap}
       />
+      
+      <Modal
+        isOpen={isPlayerModalOpen}
+        onClose={() => {
+          handleClosePlayerModal();
+          setModalPlayer(null);
+        }}
+        title={modalPlayer ? `${modalPlayer.PositionTwo ?
+                               `${modalPlayer.Position}/${modalPlayer.PositionTwo}` 
+                               : modalPlayer.Position} ${modalPlayer.Archetype} ${modalPlayer.FirstName} ${modalPlayer.LastName}` 
+                               : ''}
+        maxWidth="max-w-4xl"
+      >
+        {modalPlayer && (
+          league === SimCFB ? (
+            <CFBPlayerInfoModalBody
+              player={modalPlayer as CollegePlayer}
+            />
+          ) : (
+            <NFLDepthChartInfoModalBody
+              player={modalPlayer as NFLPlayer}
+            />
+          )
+        )}
+      </Modal>
     </div>
   );
 };

--- a/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartManager.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartManager.tsx
@@ -25,6 +25,7 @@ interface DepthChartManagerProps {
   league: typeof SimCFB | typeof SimNFL;
   selectedPosition: string;
   onPlayerMove: (playerId: number, position: string, positionLevel: number) => void;
+  onPlayerSwap: (fromPlayerId: number, toPlayerId: number, position: string, fromLevel: number, toLevel: number) => void;
   onPositionChange: (position: string) => void;
   onFormationTypeChange?: (formationType: 'offense' | 'defense' | 'specialteams') => void;
   canModify?: boolean;
@@ -45,6 +46,7 @@ const DepthChartManager: React.FC<DepthChartManagerProps> = ({
   league,
   selectedPosition,
   onPlayerMove,
+  onPlayerSwap,
   onPositionChange,
   onFormationTypeChange,
   canModify = true,
@@ -361,6 +363,7 @@ const DepthChartManager: React.FC<DepthChartManagerProps> = ({
         team={team}
         league={league}
         onPlayerMove={onPlayerMove}
+        onPlayerSwap={onPlayerSwap}
       />
     </div>
   );

--- a/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
@@ -23,6 +23,7 @@ interface DepthChartViewProps {
   depthChart: any;
   team: any;
   league: typeof SimCFB | typeof SimNFL;
+  gameplan?: any;
   onDepthChartUpdate: (updatedDepthChart: any) => void;
   onTeamChange?: (team: any) => void;
   canModify?: boolean;
@@ -39,6 +40,7 @@ const DepthChartView: React.FC<DepthChartViewProps> = ({
   depthChart,
   team,
   league,
+  gameplan,
   onDepthChartUpdate,
   onTeamChange,
   canModify = true,
@@ -294,6 +296,7 @@ const DepthChartView: React.FC<DepthChartViewProps> = ({
               depthChart={localDepthChart}
               team={team}
               league={league}
+              gameplan={gameplan}
               borderColor={borderColor}
               backgroundColor={backgroundColor}
               accentColor={accentColor}

--- a/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
@@ -88,6 +88,36 @@ const DepthChartView: React.FC<DepthChartViewProps> = ({
     setSelectedFormationType(formationType);
   }, []);
 
+  const handlePlayerSwap = useCallback((fromPlayerId: number, toPlayerId: number, position: string, fromLevel: number, toLevel: number) => {
+    if (!localDepthChart?.DepthChartPlayers) return;
+
+    let updatedPlayers = [...localDepthChart.DepthChartPlayers];
+    
+    const fromPlayerIndex = updatedPlayers.findIndex(
+      dcPlayer => dcPlayer.PlayerID === fromPlayerId && dcPlayer.Position === position && String(dcPlayer.PositionLevel) === String(fromLevel)
+    );
+    const toPlayerIndex = updatedPlayers.findIndex(
+      dcPlayer => dcPlayer.PlayerID === toPlayerId && dcPlayer.Position === position && String(dcPlayer.PositionLevel) === String(toLevel)
+    );
+    
+    if (fromPlayerIndex !== -1 && toPlayerIndex !== -1) {
+      const [swappedSlot1, swappedSlot2] = swapPlayersData(
+        updatedPlayers[fromPlayerIndex],
+        updatedPlayers[toPlayerIndex],
+        league
+      );
+      updatedPlayers[fromPlayerIndex] = swappedSlot1;
+      updatedPlayers[toPlayerIndex] = swappedSlot2;
+    }
+
+    const updatedDepthChart = {
+      ...localDepthChart,
+      DepthChartPlayers: updatedPlayers
+    };
+
+    setLocalDepthChart(updatedDepthChart);
+  }, [localDepthChart, league]);
+
   const handlePlayerMove = useCallback((playerId: number, newPosition: string, newPositionLevel: number) => {
     if (!localDepthChart?.DepthChartPlayers) return;
 
@@ -326,6 +356,7 @@ const DepthChartView: React.FC<DepthChartViewProps> = ({
               league={league}
               selectedPosition={selectedPosition}
               onPlayerMove={handlePlayerMove}
+              onPlayerSwap={handlePlayerSwap}
               onPositionChange={handlePositionSelection}
               onFormationTypeChange={handleFormationTypeChange}
               canModify={canModify}

--- a/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
@@ -286,7 +286,10 @@ const DepthChartView: React.FC<DepthChartViewProps> = ({
         <Modal
           isOpen={isModalOpen}
           onClose={handleCloseModal}
-          title={modalPlayer ? `${modalPlayer.Position} ${modalPlayer.Archetype} ${modalPlayer.FirstName} ${modalPlayer.LastName}` : ''}
+          title={modalPlayer ? `${modalPlayer.PositionTwo ?
+                               `${modalPlayer.Position}/${modalPlayer.PositionTwo}` 
+                               : modalPlayer.Position} ${modalPlayer.Archetype} ${modalPlayer.FirstName} ${modalPlayer.LastName}` 
+                               : ''}
           maxWidth="max-w-4xl"
         >
           {modalPlayer && (

--- a/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
@@ -287,7 +287,7 @@ const DepthChartView: React.FC<DepthChartViewProps> = ({
                  'Special Teams Depth Chart'}
               </Text>
               <Text variant="body" classes="text-gray-400 mt-2">
-                Visual representation of your depth chart
+                Visual representation of the depth chart
               </Text>
             </div>
             <FormationView

--- a/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
@@ -333,11 +333,6 @@ const DepthChartView: React.FC<DepthChartViewProps> = ({
               openModal={openModal}
               borderTextColor={borderTextColor}
             />
-            <div className="mt-4 text-center">
-              <Text variant="small" classes="text-gray-400">
-                Visual representation of your saved depth chart
-              </Text>
-            </div>
           </div>
         )}
           <div className="relative">

--- a/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/DepthChartView.tsx
@@ -317,7 +317,7 @@ const DepthChartView: React.FC<DepthChartViewProps> = ({
                  'Special Teams Depth Chart'}
               </Text>
               <Text variant="body" classes="text-gray-400 mt-2">
-                Visual representation of the depth chart
+                Visual representation of the depth chart for {team.TeamName}
               </Text>
             </div>
             <FormationView

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import { CollegePlayer as CFBPlayer, NFLPlayer } from '../../../../models/footballModels';
 import PositionSlot from './PositionSlot';
 import { SimCFB, SimNFL } from '../../../../_constants/constants';
 import { Text } from '../../../../_design/Typography';
+import { FormationMap, Formation } from '../Constants/GameplanConstants';
+import { Button } from '../../../../_design/Buttons';
+import { getFormationLayout, getDefensiveFormationLayout, getDefensiveLinePositions, getFormationType, shouldRenderPosition } from './FormationViewHelper';
 
 interface FormationViewProps {
   formationType: 'offense' | 'defense' | 'specialteams';
@@ -10,6 +13,7 @@ interface FormationViewProps {
   depthChart: any;
   team: any;
   league: typeof SimCFB | typeof SimNFL;
+  gameplan?: any;
   borderColor?: string;
   accentColor?: string;
   backgroundColor?: string;
@@ -23,187 +27,155 @@ const FormationView: React.FC<FormationViewProps> = ({
   depthChart,
   team,
   league,
+  gameplan,
   borderColor,
   backgroundColor,
   accentColor,
   borderTextColor,
   openModal
 }) => {
+  const [currentFormationIndex, setCurrentFormationIndex] = useState(0);
+  
+  const availableFormations = useMemo(() => {
+    if (formationType === 'offense') {
+      const offensiveScheme = gameplan?.OffensiveScheme || team?.TeamGameplan?.OffensiveScheme;
+      
+      if (!offensiveScheme) {
+        return [];
+      }
+      
+      const schemeData = FormationMap[offensiveScheme];
+      return schemeData?.Formations || [];
+    } else if (formationType === 'defense') {
+      const defensiveScheme = gameplan?.DefensiveScheme || team?.TeamGameplan?.DefensiveScheme;
+      
+      if (!defensiveScheme) {
+        return [];
+      }
+      
+      const schemeData = FormationMap[defensiveScheme];
+      return schemeData?.Formations || [];
+    }
+    
+    return [];
+  }, [formationType, gameplan?.OffensiveScheme, team?.TeamGameplan?.OffensiveScheme, gameplan?.DefensiveScheme, team?.TeamGameplan?.DefensiveScheme]);
+  
+  const currentFormation = availableFormations[currentFormationIndex] || null;
+  const defensiveScheme = gameplan?.DefensiveScheme || team?.TeamGameplan?.DefensiveScheme;
+  const formationLayout = currentFormation 
+    ? (formationType === 'defense' ? getDefensiveFormationLayout(currentFormation, defensiveScheme) : getFormationLayout(currentFormation))
+    : null;
+  
+  const handlePreviousFormation = () => {
+    setCurrentFormationIndex(prev => 
+      prev === 0 ? availableFormations.length - 1 : prev - 1
+    );
+  };
+  
+  const handleNextFormation = () => {
+    setCurrentFormationIndex(prev => 
+      prev === availableFormations.length - 1 ? 0 : prev + 1
+    );
+  };
   
   const getOffenseFormation = () => (
-    <div className="relative w-[75rem] h-[40rem] bg-gradient-to-b from-green-600 via-green-500 to-green-600 rounded-lg overflow-hidden border-2" style={{ borderColor }}>
-      <div className="absolute inset-0">
-        {[...Array(12)].map((_, i) => (
-          <div
-            key={i}
-            className="absolute w-full h-px bg-white opacity-30"
-            style={{ top: `${8 + i * 8}%` }}
-          />
-        ))}
-      </div>
-      <div className="absolute inset-0 grid grid-cols-14 grid-rows-12 gap-1 p-4">
-        <div className="col-[1_/_span_1] row-start-2 flex justify-center">
-          <PositionSlot
-            position="WR"
-            positionLevels={4} 
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="WR1"
-            startingLevel={1}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
+    <div className="space-y-4">
+      {availableFormations.length > 1 && currentFormation && (
+        <div className="flex items-center justify-center space-x-4 p-1 rounded-lg border-2" style={{ backgroundColor: backgroundColor, borderColor: borderColor }}>
+          <Button
+            onClick={handlePreviousFormation}
+            variant="secondary"
+            size="sm"
+            classes="text-white hover:bg-gray-700 transition-colors"
+          >
+            ←
+          </Button>
+          <div className="text-center">
+            <Text variant="h4" classes="text-white font-semibold">
+              {currentFormation.name}
+            </Text>
+            <Text variant="small" classes="text-gray-300">
+              {currentFormationIndex + 1} of {availableFormations.length}
+            </Text>
+          </div>
+          <Button
+            onClick={handleNextFormation}
+            variant="secondary"
+            size="sm"
+            classes="text-white hover:bg-gray-700 transition-colors"
+          >
+            →
+          </Button>
         </div>
-        <div className="col-[14_/_span_1] row-start-2 flex justify-center">
-          <PositionSlot
-            position="WR"
-            positionLevels={4}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="WR2"
-            startingLevel={2}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
+      )}
+      
+      <div className="relative w-[75rem] h-[40rem] bg-gradient-to-b from-green-600 via-green-500 to-green-600 rounded-lg overflow-hidden border-2" style={{ borderColor }}>
+        <div className="absolute inset-0">
+          {[...Array(12)].map((_, i) => (
+            <div
+              key={i}
+              className="absolute w-full h-px bg-white opacity-30"
+              style={{ top: `${8 + i * 8}%` }}
+            />
+          ))}
         </div>
-        <div className="col-[13_/_span_1] row-start-2 flex justify-center">
-          <PositionSlot
-            position="TE"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="TE1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-        </div>
-        <div className="col-[6_/_span_5] row-start-3 flex justify-center items-center gap-1">
-          <PositionSlot
-            position="LT"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="LT1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="LG"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="LG1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="C"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="C1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="RG"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="RG1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="RT"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="RT1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-        </div>
-        <div className="col-[7_/_span_1] row-start-7 flex justify-center">
-          <PositionSlot
-            position="RB"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="RB1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-        </div>
-        <div className="col-[8_/_span_1] row-start-6 flex justify-center">
-          <PositionSlot
-            position="QB"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="QB1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-        </div>
-        <div className="col-[9_/_span_1] row-start-7 flex justify-center">
-          <PositionSlot
-            position="FB"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="FB1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-        </div>
-        <div className="row-start-12 row-span-12 rounded-lg bg-opacity-75 col-[1_/_span_14] w-full border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
-          <div className="flex items-center justify-center w-full h-full">
-            <Text variant="h1" classes={`uppercase ${borderTextColor}`}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+        
+        <div className="absolute inset-0 grid grid-rows-12 p-2" style={{ gridTemplateColumns: 'repeat(14, minmax(0.5, 1fr))' }}>
+          {formationLayout?.positions.map(positionData => {
+            if (!positionData.shouldRender || !shouldRenderPosition(positionData.position, currentFormation, formationType)) {
+              return null;
+            }
+            
+            const positionType = positionData.position.replace(/\d+$/, '');
+            const positionLevel = parseInt(positionData.position.match(/\d+$/)?.[0] || '1');
+            
+            if (['LT1', 'LG1', 'C1', 'RG1', 'RT1'].includes(positionData.position)) {
+              return null;
+            }
+            return (
+              <div key={positionData.position} className={`flex justify-center`} style={{ gridColumnStart: positionData.col, gridRowStart: positionData.row }}>
+                <PositionSlot
+                  position={positionType}
+                  positionLevels={positionType === 'WR' ? 4 : 1}
+                  players={players}
+                  depthChart={depthChart}
+                  team={team}
+                  league={league}
+                  size="md"
+                  label={positionData.position}
+                  startingLevel={positionLevel}
+                  showBackupBelow={positionData.showBackup}
+                  openModal={openModal}
+                  backgroundColor={backgroundColor}
+                />
+              </div>
+            );
+          })}
+          <div className="flex justify-center items-center gap-1" style={{ gridColumnStart: 5, gridColumnEnd: 10, gridRowStart: 3 }}>
+            {['LT1', 'LG1', 'C1', 'RG1', 'RT1'].map(position => {
+              const positionType = position.replace(/\d+$/, '');
+              return (
+                <PositionSlot
+                  key={position}
+                  position={positionType}
+                  positionLevels={1}
+                  players={players}
+                  depthChart={depthChart}
+                  team={team}
+                  league={league}
+                  size="md"
+                  label={position}
+                  showBackupBelow={false}
+                  openModal={openModal}
+                  backgroundColor={backgroundColor}
+                />
+              );
+            })}
+          </div>
+          <div className="row-start-11 row-span-2 rounded-lg bg-opacity-75 col-[1_/_span_14] w-full border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
+            <div className="flex items-center justify-center w-full h-full">
+              <Text variant="h1" classes={`uppercase ${borderTextColor}`}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+            </div>
           </div>
         </div>
       </div>
@@ -211,199 +183,103 @@ const FormationView: React.FC<FormationViewProps> = ({
   );
 
   const getDefenseFormation = () => (
-    <div className="relative w-[75rem] h-[40rem] bg-gradient-to-b from-green-600 via-green-500 to-green-600 rounded-lg overflow-hidden border-2" style={{ borderColor }}>
-      <div className="absolute inset-0">
-        {[...Array(12)].map((_, i) => (
-          <div
-            key={i}
-            className="absolute w-full h-px bg-white opacity-30"
-            style={{ top: `${8 + i * 8}%` }}
-          />
-        ))}
-      </div>
-      <div className="absolute inset-0 grid grid-cols-14 grid-rows-12 gap-1 p-4">
-        <div className="col-span-7 col-start-4 row-start-9 flex justify-center items-start gap-2">
-          <PositionSlot
-            position="LE"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="LE1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="DT"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="DT1"
-            startingLevel={1}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="DT"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="DT2"
-            startingLevel={2}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="RE"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="RE1"
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-        </div>
-        <div className="col-span-9 col-start-3 row-start-6 flex justify-center items-center gap-6">
-          <PositionSlot
-            position="ROLB"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="ROLB1"
-            startingLevel={1}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="MLB"
-            positionLevels={2}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="MLB1"
-            startingLevel={1}
-            showBackupBelow={false}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="MLB"
-            positionLevels={2}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="MLB2"
-            startingLevel={2}
-            showBackupBelow={false}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-          <PositionSlot
-            position="LOLB"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="LOLB1"
-            startingLevel={1}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-        </div>
-        <div className="col-start-1 col-span-2 row-start-5 flex justify-center">
-          <PositionSlot
-            position="CB"
-            positionLevels={5}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="CB1"
-            startingLevel={1}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-        </div>
-        <div className="col-start-12 col-span-2 row-start-5 flex justify-center">
-          <PositionSlot
-            position="CB"
-            positionLevels={5}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="CB2"
-            startingLevel={2}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
-        </div>
-        <div className="col-start-1 col-[14_/_span_14] row-start-1 row-span-2 rounded-lg border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
-          <div className="flex items-center justify-center w-full h-full">
-            <Text variant="h1" classes="uppercase">{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+    <div className="space-y-4">
+      {availableFormations.length > 1 && currentFormation && (
+        <div className="flex items-center justify-center space-x-4 p-1 rounded-lg border-2" style={{ backgroundColor: backgroundColor, borderColor: borderColor }}>
+          <Button
+            onClick={handlePreviousFormation}
+            variant="secondary"
+            size="sm"
+            classes="text-white hover:bg-gray-700 transition-colors"
+          >
+            ←
+          </Button>
+          <div className="text-center">
+            <Text variant="h4" classes="text-white font-semibold">
+              {currentFormation.name}
+            </Text>
+            <Text variant="small" classes="text-gray-300">
+              {currentFormationIndex + 1} of {availableFormations.length}
+            </Text>
           </div>
+          <Button
+            onClick={handleNextFormation}
+            variant="secondary"
+            size="sm"
+            classes="text-white hover:bg-gray-700 transition-colors"
+          >
+            →
+          </Button>
         </div>
-        <div className="col-start-3 col-span-1 row-start-3 flex justify-center">
-          <PositionSlot
-            position="FS"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="FS1"
-            startingLevel={1}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
+      )}
+      
+      <div className="relative w-[75rem] h-[40rem] bg-gradient-to-b from-green-600 via-green-500 to-green-600 rounded-lg overflow-hidden border-2" style={{ borderColor }}>
+        <div className="absolute inset-0">
+          {[...Array(12)].map((_, i) => (
+            <div
+              key={i}
+              className="absolute w-full h-px bg-white opacity-30"
+              style={{ top: `${8 + i * 8}%` }}
+            />
+          ))}
         </div>
-        <div className="col-start-11 col-span-1 row-start-3 flex justify-center">
-          <PositionSlot
-            position="SS"
-            positionLevels={1}
-            players={players}
-            depthChart={depthChart}
-            team={team}
-            league={league}
-            size="md"
-            label="SS1"
-            startingLevel={1}
-            showBackupBelow={true}
-            openModal={openModal}
-            backgroundColor={backgroundColor}
-          />
+        
+        <div className="absolute inset-0 grid grid-cols-14 grid-rows-12 p-2">
+          {formationLayout?.positions.map(positionData => {
+            if (!positionData.shouldRender || !shouldRenderPosition(positionData.position, currentFormation, formationType)) {
+              return null;
+            }
+            
+            const positionType = positionData.position.replace(/\d+$/, '');
+            const positionLevel = parseInt(positionData.position.match(/\d+$/)?.[0] || '1');
+            
+            return (
+              <div key={positionData.position} className={`flex justify-center`} style={{ gridColumnStart: positionData.col, gridRowStart: positionData.row }}>
+                <PositionSlot
+                  position={positionType}
+                  positionLevels={positionType === 'CB' ? 5 : positionType === 'MLB' ? 4 : positionType === 'DT' ? 4 : 2}
+                  players={players}
+                  depthChart={depthChart}
+                  team={team}
+                  league={league}
+                  size="md"
+                  label={positionData.position}
+                  startingLevel={positionLevel}
+                  showBackupBelow={false}
+                  openModal={openModal}
+                  backgroundColor={backgroundColor}
+                />
+              </div>
+            );
+          })}
+          {currentFormation && (
+            <div className="flex justify-center items-center gap-1" style={{ gridColumnStart: 5, gridColumnEnd: 10, gridRowStart: 11 }}>
+              {getDefensiveLinePositions(currentFormation, defensiveScheme).map(position => {
+                const positionType = position.replace(/\d+$/, '');
+                return (
+                  <PositionSlot
+                    key={position}
+                    position={positionType}
+                    positionLevels={positionType === 'DT' ? 4 : 2}
+                    players={players}
+                    depthChart={depthChart}
+                    team={team}
+                    league={league}
+                    size="md"
+                    label={position}
+                    showBackupBelow={false}
+                    openModal={openModal}
+                    backgroundColor={backgroundColor}
+                  />
+                );
+              })}
+            </div>
+          )}
+          <div className="row-start-1 row-span-2 rounded-lg bg-opacity-75 col-[1_/_span_14] w-full border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
+            <div className="flex items-center justify-center w-full h-full">
+              <Text variant="h1" classes={`uppercase ${borderTextColor}`}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -432,7 +308,7 @@ const FormationView: React.FC<FormationViewProps> = ({
             size="md"
             label="K1"
             startingLevel={1}
-            showBackupBelow={true}
+            showBackupBelow={false}
             openModal={openModal}
             backgroundColor={backgroundColor}
           />
@@ -448,7 +324,7 @@ const FormationView: React.FC<FormationViewProps> = ({
             size="md"
             label="P1"
             startingLevel={1}
-            showBackupBelow={true}
+            showBackupBelow={false}
             openModal={openModal}
             backgroundColor={backgroundColor}
           />

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
@@ -181,7 +181,11 @@ const FormationView: React.FC<FormationViewProps> = ({
           <div className="row-start-11 row-span-2 rounded-lg bg-opacity-75 col-[1_/_span_14] w-full border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
             <div className="flex items-center justify-between w-full h-full px-4">
               <Logo url={logo} />
-              <Text variant="h1" classes={`uppercase ${borderTextColor}`}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+              <Text variant="h1" classes={`uppercase ${borderTextColor}`}                 style={{
+                  textShadow: borderTextColor?.includes('white') 
+                    ? '1.5px 1.5px 0 black, -1.5px -1.5px 0 black, 1.5px -1.5px 0 black, -1.5px 1.5px 0 black'
+                    : '1.5px 1.5px 0 white, -1.5px -1.5px 0 white, 1.5px -1.5px 0 white, -1.5px 1.5px 0 white'
+                }}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
               <Logo url={logo} />
             </div>
           </div>
@@ -288,7 +292,7 @@ const FormationView: React.FC<FormationViewProps> = ({
           <div className="row-start-1 row-span-2 rounded-lg bg-opacity-75 col-[1_/_span_14] w-full border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
             <div className="flex items-center justify-between w-full h-full px-4">
               <Logo url={logo} />
-              <Text variant="h1" classes={`uppercase ${borderTextColor}`}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+              <Text variant="h1" classes={`uppercase ${textColorClass}`}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
               <Logo url={logo} />
             </div>
           </div>

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
@@ -7,6 +7,8 @@ import { FormationMap, Formation } from '../Constants/GameplanConstants';
 import { Button } from '../../../../_design/Buttons';
 import { getFormationLayout, getDefensiveFormationLayout, getDefensiveLinePositions, getFormationType, shouldRenderPosition } from './FormationViewHelper';
 import { ArrowRight, ArrowLeft } from '../../../../_design/Icons';
+import { getLogo } from '../../../../_utility/getLogo';
+import { Logo } from '../../../../_design/Logo';
 
 interface FormationViewProps {
   formationType: 'offense' | 'defense' | 'specialteams';
@@ -36,7 +38,8 @@ const FormationView: React.FC<FormationViewProps> = ({
   openModal
 }) => {
   const [currentFormationIndex, setCurrentFormationIndex] = useState(0);
-  
+  const logo = getLogo(league, team.ID, false);
+
   const availableFormations = useMemo(() => {
     if (formationType === 'offense') {
       const offensiveScheme = gameplan?.OffensiveScheme || team?.TeamGameplan?.OffensiveScheme;
@@ -176,8 +179,10 @@ const FormationView: React.FC<FormationViewProps> = ({
             })}
           </div>
           <div className="row-start-11 row-span-2 rounded-lg bg-opacity-75 col-[1_/_span_14] w-full border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
-            <div className="flex items-center justify-center w-full h-full">
+            <div className="flex items-center justify-between w-full h-full px-4">
+              <Logo url={logo} />
               <Text variant="h1" classes={`uppercase ${borderTextColor}`}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+              <Logo url={logo} />
             </div>
           </div>
         </div>
@@ -281,8 +286,10 @@ const FormationView: React.FC<FormationViewProps> = ({
             </div>
           )}
           <div className="row-start-1 row-span-2 rounded-lg bg-opacity-75 col-[1_/_span_14] w-full border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
-            <div className="flex items-center justify-center w-full h-full">
+            <div className="flex items-center justify-between w-full h-full px-4">
+              <Logo url={logo} />
               <Text variant="h1" classes={`uppercase ${borderTextColor}`}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+              <Logo url={logo} />
             </div>
           </div>
         </div>

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
@@ -229,7 +229,7 @@ const FormationView: React.FC<FormationViewProps> = ({
           ))}
         </div>
         
-        <div className="absolute inset-0 grid grid-cols-14 grid-rows-12 p-2">
+        <div className="absolute grid inset-0 grid-rows-12 p-2" style={{ gridTemplateColumns: 'repeat(14, minmax(0.5, 1fr))' }}>
           {formationLayout?.positions.map(positionData => {
             if (!positionData.shouldRender || !shouldRenderPosition(positionData.position, currentFormation, formationType)) {
               return null;
@@ -301,7 +301,7 @@ const FormationView: React.FC<FormationViewProps> = ({
           />
         ))}
       </div>
-      <div className="absolute inset-0 grid grid-cols-14 grid-rows-12 gap-1 p-4">
+      <div className="absolute inset-0 grid grid-rows-12 gap-1 p-4" style={{ gridTemplateColumns: 'repeat(14, minmax(0.5, 1fr))' }}>
         <div className="col-start-2 col-span-1 row-start-9 flex justify-center">
           <PositionSlot
             position="K"

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
@@ -181,11 +181,13 @@ const FormationView: React.FC<FormationViewProps> = ({
           <div className="row-start-11 row-span-2 rounded-lg bg-opacity-75 col-[1_/_span_14] w-full border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
             <div className="flex items-center justify-between w-full h-full px-4">
               <Logo url={logo} />
-              <Text variant="h1" classes={`uppercase ${borderTextColor}`}                 style={{
-                  textShadow: borderTextColor?.includes('white') 
-                    ? '1.5px 1.5px 0 black, -1.5px -1.5px 0 black, 1.5px -1.5px 0 black, -1.5px 1.5px 0 black'
-                    : '1.5px 1.5px 0 white, -1.5px -1.5px 0 white, 1.5px -1.5px 0 white, -1.5px 1.5px 0 white'
-                }}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+              <Text variant="h1" classes={`uppercase ${borderTextColor}`}                 
+                    style={{
+                      textShadow: borderTextColor?.includes('white') 
+                        ? '1.5px 1.5px 0 black, -1.5px -1.5px 0 black, 1.5px -1.5px 0 black, -1.5px 1.5px 0 black'
+                        : '1.5px 1.5px 0 white, -1.5px -1.5px 0 white, 1.5px -1.5px 0 white, -1.5px 1.5px 0 white'
+              }}>
+                  {league === SimCFB ? team.TeamName : team.Mascot}</Text>
               <Logo url={logo} />
             </div>
           </div>
@@ -292,7 +294,13 @@ const FormationView: React.FC<FormationViewProps> = ({
           <div className="row-start-1 row-span-2 rounded-lg bg-opacity-75 col-[1_/_span_14] w-full border-2" style={{ backgroundColor: borderColor, borderColor: accentColor }}>
             <div className="flex items-center justify-between w-full h-full px-4">
               <Logo url={logo} />
-              <Text variant="h1" classes={`uppercase ${textColorClass}`}>{league === SimCFB ? team.TeamName : team.Mascot}</Text>
+              <Text variant="h1" classes={`uppercase ${borderTextColor}`}                 
+                    style={{
+                      textShadow: borderTextColor?.includes('white') 
+                        ? '1.5px 1.5px 0 black, -1.5px -1.5px 0 black, 1.5px -1.5px 0 black, -1.5px 1.5px 0 black'
+                        : '1.5px 1.5px 0 white, -1.5px -1.5px 0 white, 1.5px -1.5px 0 white, -1.5px 1.5px 0 white'
+              }}>
+                {league === SimCFB ? team.TeamName : team.Mascot}</Text>
               <Logo url={logo} />
             </div>
           </div>

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationView.tsx
@@ -6,6 +6,7 @@ import { Text } from '../../../../_design/Typography';
 import { FormationMap, Formation } from '../Constants/GameplanConstants';
 import { Button } from '../../../../_design/Buttons';
 import { getFormationLayout, getDefensiveFormationLayout, getDefensiveLinePositions, getFormationType, shouldRenderPosition } from './FormationViewHelper';
+import { ArrowRight, ArrowLeft } from '../../../../_design/Icons';
 
 interface FormationViewProps {
   formationType: 'offense' | 'defense' | 'specialteams';
@@ -81,14 +82,15 @@ const FormationView: React.FC<FormationViewProps> = ({
   const getOffenseFormation = () => (
     <div className="space-y-4">
       {availableFormations.length > 1 && currentFormation && (
-        <div className="flex items-center justify-center space-x-4 p-1 rounded-lg border-2" style={{ backgroundColor: backgroundColor, borderColor: borderColor }}>
+        <div className="flex items-center space-x-4 p-1 rounded-lg border-2 justify-center" style={{ backgroundColor: backgroundColor, borderColor: borderColor }}>
+          <div className="flex w-1/2 justify-between items-center">
           <Button
             onClick={handlePreviousFormation}
             variant="secondary"
             size="sm"
-            classes="text-white hover:bg-gray-700 transition-colors"
+            classes="text-white hover:bg-gray-700 transition-colors h-1/2"
           >
-            ←
+            <ArrowLeft />
           </Button>
           <div className="text-center">
             <Text variant="h4" classes="text-white font-semibold">
@@ -102,10 +104,11 @@ const FormationView: React.FC<FormationViewProps> = ({
             onClick={handleNextFormation}
             variant="secondary"
             size="sm"
-            classes="text-white hover:bg-gray-700 transition-colors"
+            classes="text-white hover:bg-gray-700 transition-colors h-1/2"
           >
-            →
+            <ArrowRight />
           </Button>
+          </div>
         </div>
       )}
       
@@ -185,31 +188,33 @@ const FormationView: React.FC<FormationViewProps> = ({
   const getDefenseFormation = () => (
     <div className="space-y-4">
       {availableFormations.length > 1 && currentFormation && (
-        <div className="flex items-center justify-center space-x-4 p-1 rounded-lg border-2" style={{ backgroundColor: backgroundColor, borderColor: borderColor }}>
-          <Button
-            onClick={handlePreviousFormation}
-            variant="secondary"
-            size="sm"
-            classes="text-white hover:bg-gray-700 transition-colors"
-          >
-            ←
-          </Button>
-          <div className="text-center">
-            <Text variant="h4" classes="text-white font-semibold">
-              {currentFormation.name}
-            </Text>
-            <Text variant="small" classes="text-gray-300">
-              {currentFormationIndex + 1} of {availableFormations.length}
-            </Text>
+        <div className="flex items-center space-x-4 p-1 rounded-lg border-2 justify-center" style={{ backgroundColor: backgroundColor, borderColor: borderColor }}>
+          <div className="flex w-1/2 justify-between items-center">
+            <Button
+              onClick={handlePreviousFormation}
+              variant="secondary"
+              size="sm"
+              classes="text-white hover:bg-gray-700 transition-colors h-1/2"
+            >
+              <ArrowLeft />
+            </Button>
+            <div className="text-center">
+              <Text variant="h4" classes="text-white font-semibold">
+                {currentFormation.name}
+              </Text>
+              <Text variant="small" classes="text-gray-300">
+                {currentFormationIndex + 1} of {availableFormations.length}
+              </Text>
+            </div>
+            <Button
+              onClick={handleNextFormation}
+              variant="secondary"
+              size="sm"
+              classes="text-white hover:bg-gray-700 transition-colors h-1/2"
+            >
+              <ArrowRight />
+            </Button>
           </div>
-          <Button
-            onClick={handleNextFormation}
-            variant="secondary"
-            size="sm"
-            classes="text-white hover:bg-gray-700 transition-colors"
-          >
-            →
-          </Button>
         </div>
       )}
       

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationViewHelper.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationViewHelper.tsx
@@ -84,7 +84,6 @@ export interface WRPositioning {
 
 export const getFormationType = (formationName: string, positions: string[] = []): FormationType => {
   const name = formationName.toLowerCase();
-  console.log(name)
 
   if (name.includes(FORMATION_KEYWORDS.SINGLEBACK) && !name.includes(FORMATION_KEYWORDS.GUN)) {
     return SINGLEBACK;

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationViewHelper.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationViewHelper.tsx
@@ -521,7 +521,6 @@ export const getFormationLayout = (formation: Formation): FormationLayout => {
 };
 
 export const getDefensiveFormationLayout = (formation: Formation, defensiveScheme?: string): FormationLayout => {
-  console.log(formation)
   const formationType = getDefensiveFormationType(formation.name, formation.positions, defensiveScheme);
   
   const positions: FormationPositionData[] = [];
@@ -624,7 +623,6 @@ export const getDefensiveLinePositions = (formation: Formation, defensiveScheme?
     }
   } else if (formationType === THREE_THREE_FIVE_NICKEL) {
     const rolbPosition = formation.positions.find(p => p === `${POSITION_PREFIXES.ROLB}1`);
-    console.log(rolbPosition)
     if (rolbPosition) {
       if (defensiveScheme === '2-Gap' && !formation.positions.includes(`${POSITION_PREFIXES.DT}1`)) {
         dlPositions = [...dlPositions, rolbPosition];
@@ -684,7 +682,6 @@ const addLinebackerPositions = (positions: FormationPositionData[], lbPositions:
   const lbRow = 7;
   
   let filteredLbPositions = lbPositions;
-  console.log(filteredLbPositions)
   if (formationType === FOUR_FOUR_OVER || formationType === FOUR_THREE_OVER || formationType === THREE_THREE_FIVE_OVER || formationType === THREE_FOUR_EAGLE) {
     filteredLbPositions = lbPositions.filter(p => p !== `${POSITION_PREFIXES.LOLB}1`);
   }

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationViewHelper.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationViewHelper.tsx
@@ -7,6 +7,7 @@ import {
   TIGHT,
   WING,
   EMPTY,
+  SINGLEBACK,
   FLEXBONE_GUN,
   WING_SPLIT_BACK_GUN,
   DOUBLE_WING_SPLIT,
@@ -49,7 +50,7 @@ import {
 
 export type FormationType = 
   | typeof UNDER_CENTER | typeof GUN | typeof PISTOL | typeof SPREAD | typeof TIGHT | typeof WING | typeof EMPTY 
-  | typeof FLEXBONE_GUN | typeof WING_SPLIT_BACK_GUN | typeof DOUBLE_WING_SPLIT | typeof DOUBLE_WING;
+  | typeof FLEXBONE_GUN | typeof WING_SPLIT_BACK_GUN | typeof DOUBLE_WING_SPLIT | typeof DOUBLE_WING | typeof SINGLEBACK;
 
 export type DefensiveFormationType = 
   | typeof FOUR_THREE_BASE | typeof FOUR_THREE_OVER | typeof FOUR_THREE_UNDER | typeof FOUR_THREE_LIGHT | typeof FOUR_THREE_HEAVY
@@ -83,6 +84,11 @@ export interface WRPositioning {
 
 export const getFormationType = (formationName: string, positions: string[] = []): FormationType => {
   const name = formationName.toLowerCase();
+  console.log(name)
+
+  if (name.includes(FORMATION_KEYWORDS.SINGLEBACK) && !name.includes(FORMATION_KEYWORDS.GUN)) {
+    return SINGLEBACK;
+  }
 
   if (name.includes(FORMATION_KEYWORDS.DOUBLE) && name.includes(FORMATION_KEYWORDS.WING) && name.includes(FORMATION_KEYWORDS.SPLIT)) {
     return DOUBLE_WING_SPLIT;
@@ -265,6 +271,7 @@ export const getQBPosition = (formationType: FormationType): number => {
     case TIGHT:
     case WING:
     case DOUBLE_WING:
+    case SINGLEBACK:
     default:
       return GRID_POSITIONS.ROWS[5];
   }

--- a/src/components/Gameplan/FootballGameplan/DepthChart/FormationViewHelper.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/FormationViewHelper.tsx
@@ -1,0 +1,897 @@
+import { Formation } from '../Constants/GameplanConstants';
+import {
+  UNDER_CENTER,
+  GUN,
+  PISTOL,
+  SPREAD,
+  TIGHT,
+  WING,
+  EMPTY,
+  FLEXBONE_GUN,
+  WING_SPLIT_BACK_GUN,
+  DOUBLE_WING_SPLIT,
+  DOUBLE_WING,
+  FOUR_THREE_BASE,
+  FOUR_THREE_OVER,
+  FOUR_THREE_UNDER,
+  FOUR_THREE_LIGHT,
+  FOUR_THREE_HEAVY,
+  THREE_FOUR_BASE,
+  THREE_FOUR_OVER,
+  THREE_FOUR_UNDER,
+  THREE_FOUR_OKIE,
+  THREE_FOUR_BRONCO,
+  THREE_FOUR_EAGLE,
+  THREE_FOUR_FOUR_HEAVY,
+  FOUR_FOUR_BASE,
+  FOUR_FOUR_OVER,
+  FOUR_FOUR_UNDER,
+  FOUR_FOUR_JUMBO,
+  FOUR_FOUR_HEAVY,
+  FOUR_TWO_FIVE_BASE,
+  FOUR_TWO_FIVE_NICKEL,
+  THREE_THREE_FIVE_BASE,
+  THREE_THREE_FIVE_OVER,
+  THREE_THREE_FIVE_NICKEL,
+  DIME_FOUR_ONE_SIX,
+  DIME_THREE_TWO_SIX,
+  FOUR_ONE_SIX_DIME,
+  FOUR_ONE_SIX_BIG_DIME,
+  THREE_TWO_SIX_DIME,
+  THREE_TWO_SIX_BIG_PENNY,
+  THREE_TWO_SIX_PENNY,
+  QUARTER,
+  GOAL_LINE,
+  POSITION_PREFIXES,
+  FORMATION_KEYWORDS,
+  GRID_POSITIONS
+} from '../Constants/DepthChartConstants';
+
+export type FormationType = 
+  | typeof UNDER_CENTER | typeof GUN | typeof PISTOL | typeof SPREAD | typeof TIGHT | typeof WING | typeof EMPTY 
+  | typeof FLEXBONE_GUN | typeof WING_SPLIT_BACK_GUN | typeof DOUBLE_WING_SPLIT | typeof DOUBLE_WING;
+
+export type DefensiveFormationType = 
+  | typeof FOUR_THREE_BASE | typeof FOUR_THREE_OVER | typeof FOUR_THREE_UNDER | typeof FOUR_THREE_LIGHT | typeof FOUR_THREE_HEAVY
+  | typeof THREE_FOUR_BASE | typeof THREE_FOUR_OVER | typeof THREE_FOUR_UNDER | typeof THREE_FOUR_OKIE | typeof THREE_FOUR_BRONCO | typeof THREE_FOUR_EAGLE | typeof THREE_FOUR_FOUR_HEAVY
+  | typeof FOUR_FOUR_BASE | typeof FOUR_FOUR_OVER | typeof FOUR_FOUR_UNDER | typeof FOUR_FOUR_JUMBO | typeof FOUR_FOUR_HEAVY
+  | typeof FOUR_TWO_FIVE_BASE | typeof FOUR_TWO_FIVE_NICKEL | typeof THREE_THREE_FIVE_BASE | typeof THREE_THREE_FIVE_OVER | typeof THREE_THREE_FIVE_NICKEL
+  | typeof DIME_FOUR_ONE_SIX | typeof DIME_THREE_TWO_SIX | typeof FOUR_ONE_SIX_DIME | typeof FOUR_ONE_SIX_BIG_DIME | typeof THREE_TWO_SIX_DIME | typeof THREE_TWO_SIX_BIG_PENNY | typeof THREE_TWO_SIX_PENNY
+  | typeof QUARTER | typeof GOAL_LINE;
+
+export interface FormationPositionData {
+  position: string;
+  row: number;
+  col: number | string;
+  colSpan?: number;
+  shouldRender: boolean;
+  empty?: boolean;
+  showBackup?: boolean;
+}
+
+export interface FormationLayout {
+  qbRow: number;
+  positions: FormationPositionData[];
+}
+
+export interface WRPositioning {
+  [key: string]: {
+    row: number;
+    col: number | string;
+  };
+}
+
+export const getFormationType = (formationName: string, positions: string[] = []): FormationType => {
+  const name = formationName.toLowerCase();
+
+  if (name.includes(FORMATION_KEYWORDS.DOUBLE) && name.includes(FORMATION_KEYWORDS.WING) && name.includes(FORMATION_KEYWORDS.SPLIT)) {
+    return DOUBLE_WING_SPLIT;
+  }
+
+  if (name.includes(FORMATION_KEYWORDS.DOUBLE) && name.includes(FORMATION_KEYWORDS.WING)) {
+    return DOUBLE_WING;
+  }
+
+  if (name.includes(FORMATION_KEYWORDS.FLEXBONE) && name.includes(FORMATION_KEYWORDS.GUN)) {
+    return FLEXBONE_GUN;
+  }
+
+  if (name.includes(FORMATION_KEYWORDS.WING) && name.includes(FORMATION_KEYWORDS.SPLIT) && name.includes(FORMATION_KEYWORDS.BACK) && name.includes(FORMATION_KEYWORDS.GUN)) {
+    return WING_SPLIT_BACK_GUN;
+  }
+  
+  if (name.includes(FORMATION_KEYWORDS.EMPTY) || (positions.filter(p => p.startsWith(POSITION_PREFIXES.WR)).length >= 5)) {
+    return EMPTY;
+  }
+  
+  if (name.includes(FORMATION_KEYWORDS.GUN) || name.includes(`${FORMATION_KEYWORDS.SPREAD} ${FORMATION_KEYWORDS.GUN}`)) {
+    return GUN;
+  }
+
+  if (name.includes(FORMATION_KEYWORDS.PISTOL)) {
+    return PISTOL;
+  }
+  
+  if (name.includes(FORMATION_KEYWORDS.SPREAD) || positions.filter(p => p.startsWith(POSITION_PREFIXES.WR)).length >= 3) {
+    return SPREAD;
+  }
+
+  const teCount = positions.filter(p => p.startsWith(POSITION_PREFIXES.TE)).length;
+  const hasFB = positions.some(p => p.startsWith(POSITION_PREFIXES.FB));
+  if (name.includes(`${FORMATION_KEYWORDS.DOUBLE} ${FORMATION_KEYWORDS.TIGHT}`) || name.includes(FORMATION_KEYWORDS.HEAVY) || (teCount >= 2) || (teCount >= 1 && hasFB)) {
+    return TIGHT;
+  }
+  
+  if (name.includes(FORMATION_KEYWORDS.WING)) {
+    return WING;
+  }
+  
+  return UNDER_CENTER;
+};
+
+export const getDefensiveFormationType = (formationName: string, positions: string[] = [], defensiveScheme?: string): DefensiveFormationType => {
+  const name = formationName.toLowerCase();
+  
+  if (name === '4-1-6 dime' && defensiveScheme) {
+    if (defensiveScheme === 'Speed' && positions.includes(`${POSITION_PREFIXES.SS}2`)) {
+      return FOUR_ONE_SIX_DIME;
+    } else if (defensiveScheme === '4-Man Front Spread Stopper' && !positions.includes(`${POSITION_PREFIXES.SS}2`)) {
+      return FOUR_ONE_SIX_DIME;
+    }
+  }
+
+  if (name.includes('4-4')) {
+    if (name.includes(FORMATION_KEYWORDS.JUMBO)) {
+      return FOUR_FOUR_JUMBO;
+    }
+    if (name.includes(FORMATION_KEYWORDS.HEAVY)) {
+      return FOUR_FOUR_HEAVY;
+    }
+    if (name.includes(FORMATION_KEYWORDS.OVER)) {
+      return FOUR_FOUR_OVER;
+    }
+    if (name.includes(FORMATION_KEYWORDS.UNDER)) {
+      return FOUR_FOUR_UNDER;
+    }
+    return FOUR_FOUR_BASE;
+  }
+
+  if (name.includes('3-4')) {
+    if (name.includes(FORMATION_KEYWORDS.OKIE)) {
+      return THREE_FOUR_OKIE;
+    }
+    if (name.includes(FORMATION_KEYWORDS.EAGLE)) {
+      return THREE_FOUR_EAGLE;
+    }
+    if (name.includes(FORMATION_KEYWORDS.BRONCO)) {
+      return THREE_FOUR_BRONCO;
+    }
+    if (name.includes(FORMATION_KEYWORDS.OVER)) {
+      return THREE_FOUR_OVER;
+    }
+    if (name.includes(FORMATION_KEYWORDS.UNDER)) {
+      return THREE_FOUR_UNDER;
+    }
+    if (name === '3-4-4 heavy') {
+      return THREE_FOUR_FOUR_HEAVY;
+    }
+    return THREE_FOUR_BASE;
+  }
+
+  if (name.includes('4-3')) {
+    if (name.includes(FORMATION_KEYWORDS.LIGHT)) {
+      return FOUR_THREE_LIGHT;
+    }
+    if (name.includes(FORMATION_KEYWORDS.HEAVY)) {
+      return FOUR_THREE_HEAVY;
+    }
+    if (name.includes(FORMATION_KEYWORDS.OVER)) {
+      return FOUR_THREE_OVER;
+    }
+    if (name.includes(FORMATION_KEYWORDS.UNDER)) {
+      return FOUR_THREE_UNDER;
+    }
+    return FOUR_THREE_BASE;
+  }
+
+  if (name === '3-4-4 heavy') {
+    return THREE_FOUR_FOUR_HEAVY;
+  }
+
+  if (name.includes(FORMATION_KEYWORDS.DIME) || name.includes('4-1-6') || name.includes('3-2-6')) {
+    if (name.includes(`${FORMATION_KEYWORDS.BIG} ${FORMATION_KEYWORDS.DIME}`)) {
+      return FOUR_ONE_SIX_BIG_DIME;
+    }
+    if (name.includes(`${FORMATION_KEYWORDS.BIG} ${FORMATION_KEYWORDS.PENNY}`)) {
+      return THREE_TWO_SIX_BIG_PENNY;
+    }
+    if (name.includes(FORMATION_KEYWORDS.PENNY)) {
+      return THREE_TWO_SIX_PENNY;
+    }
+    if (name === '4-1-6 dime') {
+      return FOUR_ONE_SIX_DIME;
+    }
+    if (name === '3-2-6 dime') {
+      return THREE_TWO_SIX_DIME;
+    }
+    if (name.includes('3-2-6')) {
+      return DIME_THREE_TWO_SIX;
+    }
+    return DIME_FOUR_ONE_SIX;
+  }
+
+  if (name.includes(FORMATION_KEYWORDS.NICKEL) || name.includes('4-2-5') || name.includes('3-3-5')) {
+    if (name === '4-2-5 base') {
+      return FOUR_TWO_FIVE_BASE;
+    }
+    if (name === '4-2-5 nickel') {
+      return FOUR_TWO_FIVE_NICKEL;
+    }
+    if (name === '3-3-5 base') {
+      return THREE_THREE_FIVE_BASE;
+    }
+    if (name === '3-3-5 over') {
+      return THREE_THREE_FIVE_OVER;
+    }
+    if (name === '3-3-5 nickel') {
+      return THREE_THREE_FIVE_NICKEL;
+    }
+    return FOUR_TWO_FIVE_NICKEL;
+  }
+
+  if (name.includes(FORMATION_KEYWORDS.QUARTER) || positions.filter(p => p.startsWith(POSITION_PREFIXES.CB)).length >= 4) {
+    return QUARTER;
+  }
+
+  if (name.includes(FORMATION_KEYWORDS.GOAL) && name.includes(FORMATION_KEYWORDS.LINE)) {
+    return GOAL_LINE;
+  }
+
+  return FOUR_THREE_BASE;
+};
+
+export const getQBPosition = (formationType: FormationType): number => {
+  switch (formationType) {
+    case GUN:
+    case SPREAD:
+      return GRID_POSITIONS.ROWS[7];
+    case PISTOL:
+      return GRID_POSITIONS.ROWS[6];
+    case EMPTY:
+      return GRID_POSITIONS.ROWS[7];
+    case FLEXBONE_GUN:
+      return GRID_POSITIONS.ROWS[6];
+    case UNDER_CENTER:
+    case TIGHT:
+    case WING:
+    case DOUBLE_WING:
+    default:
+      return GRID_POSITIONS.ROWS[5];
+  }
+};
+
+export const getWRPositioning = (formationType: FormationType, formationName: string, wrPositions: string[]): WRPositioning => {
+  const name = formationName.toLowerCase();
+  const positioning: WRPositioning = {};
+  let showBackup = false;
+  
+  switch (formationType) {
+
+    case 'double-wing-split':
+      wrPositions.forEach((wr, index) => {
+        switch (index) {
+          case 0:
+            positioning[wr] = { row: 2, col: 12 };
+            break;
+        }
+      });
+      break;
+    case 'empty':
+      wrPositions.forEach((wr, index) => {
+        switch (index) {
+          case 0:
+            positioning[wr] = { row: 2, col: 1 };
+            break;
+          case 1:
+            positioning[wr] = { row: 2, col: 12 };
+            break;
+          case 2:
+            positioning[wr] = { row: 3, col: 2 };
+            break;
+          case 3:
+            positioning[wr] = { row: 3, col: 11 };
+            break;
+        }
+      });
+      break;
+      
+    case 'spread':
+    case 'gun':
+      wrPositions.forEach((wr, index) => {
+        switch (index) {
+          case 0:
+            positioning[wr] = { row: 3, col: 1 };
+            break;
+          case 1:
+            positioning[wr] = { row: 3, col: 13 };
+            break;
+          case 2:
+            positioning[wr] = { row: 3, col: 2 };
+            break;
+          case 3:
+            positioning[wr] = { row: 3, col: 12 };
+            break;
+        }
+      });
+      break;
+      
+    case 'tight':
+      if (name.includes('double tight') || name.includes('heavy')) {
+        wrPositions.forEach((wr, index) => {
+          switch (index) {
+            case 0:
+              positioning[wr] = { row: 3, col: 2 };
+              break;
+            case 1:
+              positioning[wr] = { row: 3, col: 12 };
+              break;
+          }
+        });
+      } else {
+        wrPositions.forEach((wr, index) => {
+          switch (index) {
+            case 0:
+              positioning[wr] = { row: 2, col: 1 };
+              break;
+            case 1:
+              positioning[wr] = { row: 2, col: 13 };
+              break;
+          }
+        });
+      }
+      break;
+      
+    case 'pistol':
+      wrPositions.forEach((wr, index) => {
+        switch (index) {
+          case 0:
+            positioning[wr] = { row: 3, col: 1 };
+            break;
+          case 1:
+            positioning[wr] = { row: 3, col: 13 };
+            break;
+          case 2:
+            positioning[wr] = { row: 3, col: 2 };
+            break;
+          case 3:
+            positioning[wr] = { row: 3, col: 11 };
+            break;
+        }
+      });
+      break;
+      
+    case 'wing':
+      wrPositions.forEach((wr, index) => {
+        switch (index) {
+          case 0:
+            positioning[wr] = { row: 2, col: 2 };
+            break;
+          case 1:
+            positioning[wr] = { row: 2, col: 13 };
+            break;
+        }
+      });
+      break;
+      
+    case 'under-center':
+    default:
+      wrPositions.forEach((wr, index) => {
+        switch (index) {
+          case 0:
+            positioning[wr] = { row: 2, col: 1 };
+            break;
+          case 1:
+            positioning[wr] = { row: 2, col: 13 };
+            break;
+          case 2:
+            positioning[wr] = { row: 4, col: 2 };
+            break;
+        }
+      });
+      break;
+  }
+  
+  return positioning;
+};
+
+export const getTEPositioning = (_formationType: FormationType, _formationName: string, tePositions: string[]): WRPositioning => {
+  const positioning: WRPositioning = {};
+  
+  tePositions.forEach((te, index) => {
+    switch (index) {
+      case 0:
+        positioning[te] = { row: 2, col: 11 };
+        break;
+      case 1:
+        positioning[te] = { row: 2, col: 4 };
+        break;
+      case 2:
+        positioning[te] = { row: 3, col: 5 };
+        break;
+    }
+  });
+  
+  return positioning;
+};
+
+export const getFormationLayout = (formation: Formation): FormationLayout => {
+  const formationType = getFormationType(formation.name, formation.positions);
+  const qbRow = getQBPosition(formationType);
+  
+  const positions: FormationPositionData[] = [
+    { position: `${POSITION_PREFIXES.QB}1`, row: qbRow, col: GRID_POSITIONS.COLUMNS[7], shouldRender: true },
+    { position: `${POSITION_PREFIXES.LT}1`, row: GRID_POSITIONS.ROWS[3], col: GRID_POSITIONS.COLUMNS[5], shouldRender: true },
+    { position: `${POSITION_PREFIXES.LG}1`, row: GRID_POSITIONS.ROWS[3], col: GRID_POSITIONS.COLUMNS[6], shouldRender: true },
+    { position: `${POSITION_PREFIXES.C}1`, row: GRID_POSITIONS.ROWS[3], col: GRID_POSITIONS.COLUMNS[7], shouldRender: true },
+    { position: `${POSITION_PREFIXES.RG}1`, row: GRID_POSITIONS.ROWS[3], col: GRID_POSITIONS.COLUMNS[8], shouldRender: true },
+    { position: `${POSITION_PREFIXES.RT}1`, row: GRID_POSITIONS.ROWS[3], col: GRID_POSITIONS.COLUMNS[9], shouldRender: true },
+  ];
+  
+  const wrPositions = formation.positions.filter(p => p.startsWith(POSITION_PREFIXES.WR));
+  const tePositions = formation.positions.filter(p => p.startsWith(POSITION_PREFIXES.TE));
+  const rbPositions = formation.positions.filter(p => p.startsWith(POSITION_PREFIXES.RB));
+  const fbPositions = formation.positions.filter(p => p.startsWith(POSITION_PREFIXES.FB));
+  
+  const wrPositioning = getWRPositioning(formationType, formation.name, wrPositions);
+  wrPositions.forEach(wr => {
+    if (wrPositioning[wr]) {
+      positions.push({
+        position: wr,
+        row: wrPositioning[wr].row,
+        col: wrPositioning[wr].col,
+        empty: formationType === EMPTY ? true : false,
+        shouldRender: true,
+        showBackup: wr === `${POSITION_PREFIXES.WR}4` && formationType === EMPTY ? true : false,
+      });
+    }
+  });
+  
+  const tePositioning = getTEPositioning(formationType, formation.name, tePositions);
+  tePositions.forEach(te => {
+    if (tePositioning[te]) {
+      positions.push({
+        position: te,
+        row: tePositioning[te].row,
+        col: tePositioning[te].col,
+        shouldRender: true
+      });
+    }
+  });
+  
+  rbPositions.forEach((rb, index) => {
+    let rbRow: number = GRID_POSITIONS.ROWS[7];
+    let rbCol: number = GRID_POSITIONS.COLUMNS[6];
+    
+    if (formationType === GUN || formationType === SPREAD) {
+      rbRow = GRID_POSITIONS.ROWS[6];
+    } else if (formationType === PISTOL) {
+      rbRow = GRID_POSITIONS.ROWS[7];
+    }
+    
+    if (index === 1) {
+      rbCol = GRID_POSITIONS.COLUMNS[8];
+    }
+
+    if (index === 0 && formationType === DOUBLE_WING_SPLIT){
+      rbCol = GRID_POSITIONS.COLUMNS[2];
+      rbRow = GRID_POSITIONS.ROWS[3];
+    }
+
+    if (index === 1 && formationType === FLEXBONE_GUN){
+      rbCol = GRID_POSITIONS.COLUMNS[7];
+      rbRow = GRID_POSITIONS.ROWS[9];
+    }
+
+    if (index === 1 && formationType === WING_SPLIT_BACK_GUN){
+      rbCol = GRID_POSITIONS.COLUMNS[12];
+      rbRow = GRID_POSITIONS.ROWS[3];
+    }
+    
+    positions.push({
+      position: rb,
+      row: rbRow,
+      col: rbCol,
+      shouldRender: true
+    });
+  });
+  
+  fbPositions.forEach(fb => {
+    positions.push({
+      position: fb,
+      row: GRID_POSITIONS.ROWS[7],
+      col: GRID_POSITIONS.COLUMNS[8],
+      shouldRender: true
+    });
+  });
+  
+  return {
+    qbRow,
+    positions
+  };
+};
+
+export const getDefensiveFormationLayout = (formation: Formation, defensiveScheme?: string): FormationLayout => {
+  console.log(formation)
+  const formationType = getDefensiveFormationType(formation.name, formation.positions, defensiveScheme);
+  
+  const positions: FormationPositionData[] = [];
+  const dlPositions = formation.positions.filter(p => [POSITION_PREFIXES.RE, POSITION_PREFIXES.DT, POSITION_PREFIXES.LE, POSITION_PREFIXES.DE].some(pos => p.startsWith(pos)));
+
+  const lbPositions = formation.positions.filter(p => [POSITION_PREFIXES.LOLB, POSITION_PREFIXES.MLB, POSITION_PREFIXES.ROLB, POSITION_PREFIXES.OLB, POSITION_PREFIXES.ILB].some(pos => p.startsWith(pos)));
+  const dbPositions = formation.positions.filter(p => [POSITION_PREFIXES.CB, POSITION_PREFIXES.FS, POSITION_PREFIXES.SS].some(pos => p.startsWith(pos)));
+  
+  switch (formationType) {
+    case FOUR_THREE_BASE:
+    case FOUR_THREE_OVER:
+    case FOUR_THREE_UNDER:
+      addLinebackerPositions(positions, lbPositions, formationType, 3, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+    case FOUR_THREE_LIGHT:
+    case FOUR_THREE_HEAVY:
+      addLinebackerPositions(positions, lbPositions, formationType, 3, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+    case THREE_FOUR_BASE:
+    case THREE_FOUR_OVER: 
+    case THREE_FOUR_UNDER:
+    case THREE_FOUR_OKIE:
+    case THREE_FOUR_BRONCO:
+      addLinebackerPositions(positions, lbPositions, formationType, 4, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+    case THREE_FOUR_FOUR_HEAVY:
+      addLinebackerPositions(positions, lbPositions, formationType, 4, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+    case FOUR_FOUR_BASE:
+    case FOUR_FOUR_OVER:
+    case FOUR_FOUR_UNDER:
+      addLinebackerPositions(positions, lbPositions, formationType, 4, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+    case FOUR_FOUR_JUMBO:
+    case FOUR_FOUR_HEAVY:
+      addLinebackerPositions(positions, lbPositions, formationType, 4, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+    case FOUR_TWO_FIVE_BASE:
+    case FOUR_TWO_FIVE_NICKEL:
+    case THREE_FOUR_EAGLE:
+      addLinebackerPositions(positions, lbPositions, formationType, 2, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+    case THREE_THREE_FIVE_BASE:
+    case THREE_THREE_FIVE_OVER:
+    case THREE_THREE_FIVE_NICKEL:
+      addLinebackerPositions(positions, lbPositions, formationType, 3, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+    case DIME_FOUR_ONE_SIX:
+    case FOUR_ONE_SIX_DIME:
+    case FOUR_ONE_SIX_BIG_DIME:
+      addLinebackerPositions(positions, lbPositions, formationType, 1, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+    case DIME_THREE_TWO_SIX:
+    case THREE_TWO_SIX_DIME:
+    case THREE_TWO_SIX_BIG_PENNY:
+    case THREE_TWO_SIX_PENNY:
+      addLinebackerPositions(positions, lbPositions, formationType, 2, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+      
+    default:
+      addLinebackerPositions(positions, lbPositions, formationType, 3, formation, defensiveScheme);
+      addSecondaryPositions(positions, dbPositions, formationType);
+      break;
+  }
+  
+  return {
+    qbRow: 5,
+    positions
+  };
+};
+
+export const getDefensiveLinePositions = (formation: Formation, defensiveScheme?: string): string[] => {
+  const formationType = getDefensiveFormationType(formation.name, formation.positions, defensiveScheme);
+  let dlPositions = formation.positions.filter(p => [POSITION_PREFIXES.RE, POSITION_PREFIXES.DT, POSITION_PREFIXES.LE, POSITION_PREFIXES.DE].some(pos => p.startsWith(pos)));
+  
+  if (formationType === FOUR_FOUR_OVER || formationType === FOUR_THREE_OVER) {
+    const lolbPosition = formation.positions.find(p => p === `${POSITION_PREFIXES.LOLB}1`);
+    if (lolbPosition) {
+      dlPositions = [lolbPosition, ...dlPositions];
+    }
+  } else if (formationType === FOUR_FOUR_UNDER) {
+    const rolbPosition = formation.positions.find(p => p === `${POSITION_PREFIXES.ROLB}1`);
+    if (rolbPosition) {
+      dlPositions = [...dlPositions, rolbPosition];
+    }
+  } else if (formationType === THREE_FOUR_BRONCO || formationType === THREE_TWO_SIX_DIME) {
+    const rolbPosition = formation.positions.find(p => p === `${POSITION_PREFIXES.ROLB}1`);
+    if (rolbPosition) {
+      dlPositions = [...dlPositions, rolbPosition];
+    }
+  } else if (formationType === THREE_THREE_FIVE_NICKEL) {
+    const rolbPosition = formation.positions.find(p => p === `${POSITION_PREFIXES.ROLB}1`);
+    console.log(rolbPosition)
+    if (rolbPosition) {
+      if (defensiveScheme === '2-Gap' && !formation.positions.includes(`${POSITION_PREFIXES.DT}1`)) {
+        dlPositions = [...dlPositions, rolbPosition];
+      } else if (defensiveScheme === 'Multiple' && formation.positions.includes(`${POSITION_PREFIXES.DT}1`)) {
+        dlPositions = [...dlPositions, rolbPosition];
+      }
+    }
+  } else if (formationType === THREE_THREE_FIVE_OVER || formationType === THREE_FOUR_EAGLE) {
+    const lolbPosition = formation.positions.find(p => p === `${POSITION_PREFIXES.LOLB}1`);
+    const rolbPosition = formation.positions.find(p => p === `${POSITION_PREFIXES.ROLB}1`);
+    if (lolbPosition && rolbPosition) {
+      dlPositions = [lolbPosition, ...dlPositions, rolbPosition];
+    }
+  }
+  
+  if (formationType.includes('3-') && !formationType.includes('4-3')) {
+    return dlPositions.sort((a, b) => {
+      const order = [`${POSITION_PREFIXES.ROLB}1`, `${POSITION_PREFIXES.RE}1`, `${POSITION_PREFIXES.DT}1`, `${POSITION_PREFIXES.LE}1`, `${POSITION_PREFIXES.LOLB}1`];
+      const aIndex = order.findIndex(pos => a === pos);
+      const bIndex = order.findIndex(pos => b === pos);
+      
+      if (aIndex !== -1 && bIndex !== -1) {
+        return aIndex - bIndex;
+      }
+      
+      if (a.startsWith(POSITION_PREFIXES.RE)) return -1;
+      if (b.startsWith(POSITION_PREFIXES.RE)) return 1;
+      if (a.startsWith(POSITION_PREFIXES.DT)) return b.startsWith(POSITION_PREFIXES.LE) ? -1 : 0;
+      if (b.startsWith(POSITION_PREFIXES.DT)) return a.startsWith(POSITION_PREFIXES.LE) ? 1 : 0;
+      return 0;
+    });
+  } else {
+    return dlPositions.sort((a, b) => {
+      const order = [`${POSITION_PREFIXES.ROLB}1`, `${POSITION_PREFIXES.RE}1`, `${POSITION_PREFIXES.DT}1`, `${POSITION_PREFIXES.DT}2`, `${POSITION_PREFIXES.LE}1`, `${POSITION_PREFIXES.LOLB}1`];
+      const aIndex = order.findIndex(pos => a === pos);
+      const bIndex = order.findIndex(pos => b === pos);
+      
+      if (aIndex !== -1 && bIndex !== -1) {
+        return aIndex - bIndex;
+      }
+      
+      if (a.startsWith(POSITION_PREFIXES.RE)) return -1;
+      if (b.startsWith(POSITION_PREFIXES.RE)) return 1;
+      if (a.startsWith(POSITION_PREFIXES.LE)) return 1;
+      if (b.startsWith(POSITION_PREFIXES.LE)) return -1;
+      if (a.startsWith(POSITION_PREFIXES.DT) && b.startsWith(POSITION_PREFIXES.DT)) {
+        const aNum = parseInt(a.match(/\d+$/)?.[0] || '1');
+        const bNum = parseInt(b.match(/\d+$/)?.[0] || '1');
+        return aNum - bNum;
+      }
+      return 0;
+    });
+  }
+};
+
+const addLinebackerPositions = (positions: FormationPositionData[], lbPositions: string[], formationType: DefensiveFormationType, expectedCount: number, formation?: Formation, defensiveScheme?: string) => {
+  const lbRow = 7;
+  
+  let filteredLbPositions = lbPositions;
+  console.log(filteredLbPositions)
+  if (formationType === FOUR_FOUR_OVER || formationType === FOUR_THREE_OVER || formationType === THREE_THREE_FIVE_OVER || formationType === THREE_FOUR_EAGLE) {
+    filteredLbPositions = lbPositions.filter(p => p !== `${POSITION_PREFIXES.LOLB}1`);
+  }
+  if (formationType === FOUR_FOUR_UNDER || formationType === THREE_FOUR_BRONCO) {
+    filteredLbPositions = lbPositions.filter(p => p !== `${POSITION_PREFIXES.ROLB}1`);
+  }
+  if (formationType === THREE_THREE_FIVE_NICKEL && formation) {
+    if (defensiveScheme === '2-Gap' && !formation.positions.includes(`${POSITION_PREFIXES.DT}1`)) {
+      filteredLbPositions = lbPositions.filter(p => p !== `${POSITION_PREFIXES.ROLB}1`);
+    } else if (defensiveScheme === 'Multiple' && formation.positions.includes(`${POSITION_PREFIXES.DT}1`)) {
+      filteredLbPositions = lbPositions.filter(p => p !== `${POSITION_PREFIXES.ROLB}1` && p !== `${POSITION_PREFIXES.LOLB}1`);
+    }
+  }
+  if (formationType === THREE_TWO_SIX_DIME) {
+    filteredLbPositions = lbPositions.filter(p => p !== `${POSITION_PREFIXES.ROLB}1`);
+  }
+  if (formationType === THREE_FOUR_EAGLE) {
+    filteredLbPositions = lbPositions.filter(p => p !== `${POSITION_PREFIXES.ROLB}1` && p !== `${POSITION_PREFIXES.LOLB}1`);
+  }
+  
+  switch (expectedCount) {
+    case 4:
+      filteredLbPositions.forEach((position) => {
+        let col;
+        
+        if (position.startsWith(POSITION_PREFIXES.ROLB)) {
+          col = 5;
+        } else if (position.startsWith(POSITION_PREFIXES.LOLB)) {
+          col = 9;
+        } else if (position.startsWith(POSITION_PREFIXES.MLB)) {
+          const mlbNumber = parseInt(position.match(/\d+$/)?.[0] || '1');
+          col = mlbNumber === 1 ? 7 : 6;
+        }
+        
+        if (col) {
+          positions.push({
+            position,
+            row: lbRow,
+            col,
+            shouldRender: true,
+            showBackup: true
+          });
+        }
+      });
+      break;
+      
+    case 3:
+      filteredLbPositions.forEach((position) => {
+        let col;
+        
+        if (position.startsWith(POSITION_PREFIXES.ROLB)) {
+          col = 5;
+        } else if (position.startsWith(POSITION_PREFIXES.MLB)) {
+          const mlbNumber = parseInt(position.match(/\d+$/)?.[0] || '1');
+          col = mlbNumber === 1 ? 7 : 6;
+        } else if (position.startsWith(POSITION_PREFIXES.LOLB)) {
+          col = 9;
+        }
+        
+        if (col) {
+          positions.push({
+            position,
+            row: lbRow,
+            col,
+            shouldRender: true,
+            showBackup: true
+          });
+        }
+      });
+      break;
+      
+    case 2:
+      filteredLbPositions.forEach((position) => {
+        let col;
+
+        if (position.startsWith(POSITION_PREFIXES.MLB)) {
+          const mlbNumber = parseInt(position.match(/\d+$/)?.[0] || '1');
+          col = mlbNumber === 1 ? 7 : 6;
+        } else if (position.startsWith(POSITION_PREFIXES.ROLB)) {
+          col = 5;
+        } else if (position.startsWith(POSITION_PREFIXES.LOLB)) {
+          col = 9;
+        }
+        
+        if (col) {
+          positions.push({
+            position,
+            row: lbRow,
+            col,
+            shouldRender: true,
+            showBackup: true
+          });
+        }
+      });
+      break;
+      
+    case 1:
+      if (lbPositions.length > 0) {
+        positions.push({
+          position: lbPositions[0],
+          row: lbRow,
+          col: 7,
+          shouldRender: true,
+          showBackup: true
+        });
+      }
+      break;
+  }
+};
+
+const addSecondaryPositions = (positions: FormationPositionData[], dbPositions: string[], formationType: DefensiveFormationType) => {
+  const cbPositions = dbPositions.filter(p => p.startsWith(POSITION_PREFIXES.CB));
+  const safetyPositions = dbPositions.filter(p => p.startsWith(POSITION_PREFIXES.FS) || p.startsWith(POSITION_PREFIXES.SS));
+  
+  cbPositions.forEach((position, index) => {
+    let row = 5;
+    let col;
+    
+    const cbNumber = parseInt(position.match(/\d+$/)?.[0] || (index + 1).toString());
+    
+    switch (cbNumber) {
+      case 1:
+        col = 1;
+        row = 7;
+        break;
+      case 2:
+        col = 13;
+        row = 7; 
+        break;
+      case 3:
+        row = 5;
+        col = 4;
+        break;
+      case 4:
+        row = 5;
+        col = 11;
+        break;
+      case 5:
+        row = 3;
+        col = 7;
+        break;
+      default:
+        col = index <= 1 ? (index === 0 ? 1 : 13) : 7;
+        break;
+    }
+    
+    positions.push({
+      position,
+      row,
+      col,
+      shouldRender: true,
+      showBackup: true
+    });
+  });
+  
+  safetyPositions.forEach((position) => {
+    let row = 3;
+    let col;
+    
+    if (formationType === FOUR_THREE_HEAVY && position === `${POSITION_PREFIXES.SS}2`) {
+      row = 7;
+      col = 3;
+    } else if (formationType === FOUR_FOUR_JUMBO && (position === `${POSITION_PREFIXES.SS}1` || position === `${POSITION_PREFIXES.SS}2`)) {
+      row = 7;
+      col = position === `${POSITION_PREFIXES.SS}1` ? 8 : 9;
+    } else if (formationType === FOUR_FOUR_JUMBO && (position === `${POSITION_PREFIXES.FS}1`)) {
+      col = 7;
+    } else if (formationType === THREE_FOUR_FOUR_HEAVY && position === `${POSITION_PREFIXES.SS}1`) {
+      row = 7;
+      col = 3;
+    } else if (formationType === FOUR_FOUR_HEAVY && position === `${POSITION_PREFIXES.SS}1`) {
+      row = 7;
+      col = 3;
+    } else {
+      if (position.startsWith(POSITION_PREFIXES.FS) && formationType !== FOUR_FOUR_JUMBO) {
+        col = 5;
+      } else if (position.startsWith(POSITION_PREFIXES.SS)) {
+        const ssNumber = parseInt(position.match(/\d+$/)?.[0] || '1');
+        if (ssNumber === 1) {
+          col = 9;
+        } else {
+          col = 7;
+        }
+      } else {
+        col = 7;
+      }
+    }
+    
+    positions.push({
+      position,
+      row,
+      col,
+      shouldRender: true,
+      showBackup: true
+    });
+  });
+};
+
+export const shouldRenderPosition = (position: string, formation: Formation | null, formationType: string): boolean => {
+  if (formationType === 'defense' || formationType === 'specialteams' || !formation) {
+    return true; 
+  }
+  
+  const basePosition = position.replace(/\d+$/, '');
+  if ([POSITION_PREFIXES.QB, POSITION_PREFIXES.LT, POSITION_PREFIXES.LG, POSITION_PREFIXES.C, POSITION_PREFIXES.RG, POSITION_PREFIXES.RT].includes(basePosition as any)) {
+    return true;
+  }
+  
+  return formation.positions.includes(position);
+};

--- a/src/components/Gameplan/FootballGameplan/DepthChart/Modal/DepthChartModal.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/Modal/DepthChartModal.tsx
@@ -24,6 +24,7 @@ interface DepthChartModalProps {
   team: any;
   league: typeof SimCFB | typeof SimNFL;
   onPlayerMove: (playerId: number, position: string, positionLevel: number) => void;
+  onPlayerSwap: (fromPlayerId: number, toPlayerId: number, position: string, fromLevel: number, toLevel: number) => void;
 }
 
 const DepthChartModal: React.FC<DepthChartModalProps> = ({
@@ -34,7 +35,8 @@ const DepthChartModal: React.FC<DepthChartModalProps> = ({
   depthChart,
   team,
   league,
-  onPlayerMove
+  onPlayerMove,
+  onPlayerSwap
 }) => {
   const [showAttributes, setShowAttributes] = useState(false);
   const [swapTargetLevel, setSwapTargetLevel] = useState<number | null>(null);
@@ -80,14 +82,10 @@ const DepthChartModal: React.FC<DepthChartModalProps> = ({
       const fromPlayer = allAssigned.find(p => p.PositionLevel === fromLevel);
       const toPlayer = allAssigned.find(p => p.PositionLevel === toLevel);
       
-      if (fromPlayer && fromPlayer.playerData) {
+      if (fromPlayer && fromPlayer.playerData && toPlayer && toPlayer.playerData) {
         const fromPlayerId = (fromPlayer.playerData as any).PlayerID || (fromPlayer.playerData as any).ID;
-        onPlayerMove(fromPlayerId, modalPosition, toLevel);
-      }
-      
-      if (toPlayer && toPlayer.playerData) {
         const toPlayerId = (toPlayer.playerData as any).PlayerID || (toPlayer.playerData as any).ID;
-        onPlayerMove(toPlayerId, modalPosition, fromLevel);
+        onPlayerSwap(fromPlayerId, toPlayerId, modalPosition, fromLevel, toLevel);
       }
     }
   };

--- a/src/components/Gameplan/FootballGameplan/DepthChart/Modal/DepthChartModal.tsx
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/Modal/DepthChartModal.tsx
@@ -9,7 +9,8 @@ import PlayerAttributeCard from '../../Common/PlayerAttributeCard';
 import {
   getUnassignedPlayersForPosition,
   getAllAssignedPlayersForPosition,
-  getOverarchingPosition
+  getOverarchingPosition,
+  isPlayerOnTeam
 } from './DepthChartModalHelper';
 import { 
   ArrowsUpDown 
@@ -82,10 +83,33 @@ const DepthChartModal: React.FC<DepthChartModalProps> = ({
       const fromPlayer = allAssigned.find(p => p.PositionLevel === fromLevel);
       const toPlayer = allAssigned.find(p => p.PositionLevel === toLevel);
       
-      if (fromPlayer && fromPlayer.playerData && toPlayer && toPlayer.playerData) {
+      const hasFromPlayer = fromPlayer && fromPlayer.playerData;
+      const hasToPlayer = toPlayer && toPlayer.playerData;
+      
+      if (hasFromPlayer && hasToPlayer) {
         const fromPlayerId = (fromPlayer.playerData as any).PlayerID || (fromPlayer.playerData as any).ID;
         const toPlayerId = (toPlayer.playerData as any).PlayerID || (toPlayer.playerData as any).ID;
-        onPlayerSwap(fromPlayerId, toPlayerId, modalPosition, fromLevel, toLevel);
+        
+        const fromPlayerOnTeam = isPlayerOnTeam(fromPlayerId, players);
+        const toPlayerOnTeam = isPlayerOnTeam(toPlayerId, players);
+        
+        if (fromPlayerOnTeam && toPlayerOnTeam) {
+          onPlayerSwap(fromPlayerId, toPlayerId, modalPosition, fromLevel, toLevel);
+        } else if (fromPlayerOnTeam && !toPlayerOnTeam) {
+          onPlayerMove(fromPlayerId, modalPosition, toLevel);
+        } else {
+          console.warn('Cannot swap - from player is no longer on team');
+        }
+      } else if (hasFromPlayer && !hasToPlayer) {
+        const fromPlayerId = (fromPlayer.playerData as any).PlayerID || (fromPlayer.playerData as any).ID;
+        if (isPlayerOnTeam(fromPlayerId, players)) {
+          onPlayerMove(fromPlayerId, modalPosition, toLevel);
+        }
+      } else if (!hasFromPlayer && hasToPlayer) {
+        const toPlayerId = (toPlayer.playerData as any).PlayerID || (toPlayer.playerData as any).ID;
+        if (isPlayerOnTeam(toPlayerId, players)) {
+          onPlayerMove(toPlayerId, modalPosition, fromLevel);
+        }
       }
     }
   };

--- a/src/components/Gameplan/FootballGameplan/DepthChart/Modal/DepthChartModalHelper.ts
+++ b/src/components/Gameplan/FootballGameplan/DepthChart/Modal/DepthChartModalHelper.ts
@@ -314,3 +314,21 @@ export const swapPlayersData = (
   
   return [swappedSlot1, swappedSlot2];
 };
+
+export const clearPlayerFromSlot = (slot: any): any => ({
+  ...slot,
+  PlayerID: 0,
+  FirstName: '',
+  LastName: '',
+  OriginalPosition: ''
+});
+
+export const isPlayerOnTeam = (
+  playerId: number,
+  players: (CollegePlayer | NFLPlayer)[]
+): boolean => {
+  return players.some(player => {
+    const id = (player as any).PlayerID || (player as any).ID;
+    return id === playerId;
+  });
+};

--- a/src/components/Gameplan/FootballGameplan/FootballGameplanPage.tsx
+++ b/src/components/Gameplan/FootballGameplan/FootballGameplanPage.tsx
@@ -168,6 +168,7 @@ export const CFBGameplanPage = () => {
           depthChart={selectedTeamDepthChart || cfbDepthChart}
           team={selectedTeam}
           league={SimCFB}
+          gameplan={cfbGameplan}
           onDepthChartUpdate={handleDepthChartUpdate}
           canModify={selectedTeam?.ID === cfbTeam?.ID}
           backgroundColor={backgroundColor}
@@ -350,6 +351,7 @@ export const NFLGameplanPage = () => {
           depthChart={selectedTeamDepthChart || nflDepthChart}
           team={selectedTeam}
           league={SimNFL}
+          gameplan={nflGameplan}
           onDepthChartUpdate={handleDepthChartUpdate}
           canModify={selectedTeam?.ID === nflTeam?.ID}
           backgroundColor={backgroundColor}

--- a/src/components/Gameplan/FootballGameplan/FootballGameplanPage.tsx
+++ b/src/components/Gameplan/FootballGameplan/FootballGameplanPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { useSimFBAStore } from "../../../context/SimFBAContext";
+import { useAuthStore } from "../../../context/AuthContext";
 import { DepthChartService } from "../../../_services/depthChartService";
 import {
   CollegeGameplan as CFBGameplan,
@@ -18,10 +19,11 @@ import {
   SimCFB,
   SimNFL,
   Gameplan,
-  DepthChart
+  DepthChart,
+  AdminRole
 } from "../../../_constants/constants";
 import { Text } from "../../../_design/Typography";
-import { Input } from "../../../_design/Inputs";
+import { Input, ToggleSwitch } from "../../../_design/Inputs";
 import { SelectDropdown } from "../../../_design/Select";
 import { SelectOption } from "../../../_hooks/useSelectStyles";
 import { SingleValue } from "react-select";
@@ -36,6 +38,7 @@ import { getTextColorBasedOnBg } from '../../../_utility/getBorderClass';
 import UnsavedChangesModal from "./Common/UnsavedChangesModal";
 
 export const CFBGameplanPage = () => {
+  const { currentUser } = useAuthStore();
   const fbStore = useSimFBAStore();
   const {
     cfbTeam,
@@ -52,9 +55,10 @@ export const CFBGameplanPage = () => {
   const [isUnsavedChangesModalOpen, setIsUnsavedChangesModalOpen] = useState(false);
   const [depthChartHasUnsavedChanges, setDepthChartHasUnsavedChanges] = useState(false);
   const [gameplanHasUnsavedChanges, setGameplanHasUnsavedChanges] = useState(false);
+  const [adminModeEnabled, setAdminModeEnabled] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState(cfbTeam);
   const [selectedTeamDepthChart, setSelectedTeamDepthChart] = useState<CFBDepthChart | null>(null);
-  
+
   const teamPlayers = useMemo(() => {
     if (selectedTeam && cfbRosterMap) {
       return cfbRosterMap[selectedTeam.ID] || [];
@@ -80,6 +84,7 @@ export const CFBGameplanPage = () => {
       if (team) {
         setSelectedTeam(team);
         setDepthChartHasUnsavedChanges(false);
+        setAdminModeEnabled(false);
       }
     }
   }, [cfbTeamMap]);
@@ -141,15 +146,26 @@ export const CFBGameplanPage = () => {
             </Button>
           </ButtonGroup>
           {category === DepthChart && cfbTeamOptions && (
-          <div className="2xl:ml-4 w-full 2xl:w-auto" style={{ minWidth: '200px', maxWidth: '300px' }}>
-            <SelectDropdown
-              options={cfbTeamOptions}
-              value={cfbTeamOptions.find(opt => opt.value === String(selectedTeam?.ID))}
-              onChange={handleTeamSelection}
-              placeholder="Select Team"
-              isClearable={false}
-            />
-          </div>
+            <div className="flex flex-col 2xl:flex-row items-center gap-4">
+              <div className="2xl:ml-4 w-full 2xl:w-auto" style={{ minWidth: '200px', maxWidth: '300px' }}>
+                <SelectDropdown
+                  options={cfbTeamOptions}
+                  value={cfbTeamOptions.find(opt => opt.value === String(selectedTeam?.ID))}
+                  onChange={handleTeamSelection}
+                  placeholder="Select Team"
+                  isClearable={false}
+                />
+              </div>
+              {currentUser?.roleID && currentUser.roleID === AdminRole && selectedTeam?.ID !== cfbTeam?.ID && (
+                <div className="flex justify-center items-center gap-2">
+                  <ToggleSwitch
+                    onChange={(checked) => setAdminModeEnabled(checked)}
+                    checked={adminModeEnabled}
+                  />
+                  <Text variant="small" classes="text-white">Admin Mode</Text>
+                </div>
+              )}
+            </div>
           )}
         </div>
       </div>
@@ -170,7 +186,7 @@ export const CFBGameplanPage = () => {
           league={SimCFB}
           gameplan={cfbGameplan}
           onDepthChartUpdate={handleDepthChartUpdate}
-          canModify={selectedTeam?.ID === cfbTeam?.ID}
+          canModify={selectedTeam?.ID === cfbTeam?.ID || (currentUser?.roleID === AdminRole && adminModeEnabled)}
           backgroundColor={backgroundColor}
           borderColor={borderColor}
           accentColor={accentColor}
@@ -215,6 +231,7 @@ export const CFBGameplanPage = () => {
 
 export const NFLGameplanPage = () => {
   const { teamId } = useParams<{ teamId?: string }>();
+  const { currentUser } = useAuthStore();
   const fbStore = useSimFBAStore();
   const {
     nflTeam,
@@ -230,6 +247,7 @@ export const NFLGameplanPage = () => {
   const [isUnsavedChangesModalOpen, setIsUnsavedChangesModalOpen] = useState(false);
   const [depthChartHasUnsavedChanges, setDepthChartHasUnsavedChanges] = useState(false);
   const [gameplanHasUnsavedChanges, setGameplanHasUnsavedChanges] = useState(false);
+  const [adminModeEnabled, setAdminModeEnabled] = useState(false);
 
   const [selectedTeam, setSelectedTeam] = useState(() => {
     if (teamId && nflTeamMap) {
@@ -261,6 +279,7 @@ export const NFLGameplanPage = () => {
       if (team) {
         setSelectedTeam(team);
         setDepthChartHasUnsavedChanges(false);
+        setAdminModeEnabled(false);
       }
     }
   }, [nflTeamMap]);
@@ -324,14 +343,25 @@ export const NFLGameplanPage = () => {
               </Button>
             </ButtonGroup>
             {category === DepthChart && nflTeamOptions && (
-              <div className="2xl:ml-4 w-full 2xl:w-auto" style={{ minWidth: '200px', maxWidth: '300px' }}>
-                <SelectDropdown
-                  options={nflTeamOptions}
-                  value={nflTeamOptions.find(opt => opt.value === String(selectedTeam?.ID))}
-                  onChange={handleTeamSelection}
-                  placeholder="Select Team"
-                  isClearable={false}
-                />
+              <div className="flex flex-col 2xl:flex-row items-center gap-4">
+                <div className="2xl:ml-4 w-full 2xl:w-auto" style={{ minWidth: '200px', maxWidth: '300px' }}>
+                  <SelectDropdown
+                    options={nflTeamOptions}
+                    value={nflTeamOptions.find(opt => opt.value === String(selectedTeam?.ID))}
+                    onChange={handleTeamSelection}
+                    placeholder="Select Team"
+                    isClearable={false}
+                  />
+                </div>
+                {currentUser?.roleID && currentUser.roleID === AdminRole && selectedTeam?.ID !== nflTeam?.ID && (
+                  <div className="flex justify-center items-center gap-2">
+                    <ToggleSwitch
+                      onChange={(checked) => setAdminModeEnabled(checked)}
+                      checked={adminModeEnabled}
+                    />
+                    <Text variant="small" classes="text-white">Admin Mode</Text>
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -353,7 +383,7 @@ export const NFLGameplanPage = () => {
           league={SimNFL}
           gameplan={nflGameplan}
           onDepthChartUpdate={handleDepthChartUpdate}
-          canModify={selectedTeam?.ID === nflTeam?.ID}
+          canModify={selectedTeam?.ID === nflTeam?.ID || (currentUser?.roleID === AdminRole && adminModeEnabled)}
           backgroundColor={backgroundColor}
           borderColor={borderColor}
           accentColor={accentColor}

--- a/src/components/Gameplan/FootballGameplan/Utils/ComponentStyleUtils.ts
+++ b/src/components/Gameplan/FootballGameplan/Utils/ComponentStyleUtils.ts
@@ -63,7 +63,88 @@ export const generateSimpleBackgroundPattern = (accentColor: string): React.CSSP
 };
 
 export const generateCardGradient = (backgroundColor: string): string => {
-  return `linear-gradient(135deg, ${backgroundColor} 0%, ${backgroundColor}dd 100%)`;
+  return `linear-gradient(135deg, ${backgroundColor} 50%, ${backgroundColor}dd 100%)`;
+};
+
+export type BackgroundPatternType = 'squares' | 'simple-squares' | 'stripes' | 'dots' | 'hexagon' | 'waves' | 'triangles' | 'cross' | 'texture' | 'none';
+
+export const generateStripedPattern = (accentColor: string): React.CSSProperties => {
+  return {
+    backgroundImage: `repeating-linear-gradient(45deg, ${accentColor} 0px, ${accentColor} 2px, transparent 2px, transparent 8px)`,
+  };
+};
+
+export const generateDotPattern = (accentColor: string): React.CSSProperties => {
+  return {
+    backgroundImage: `radial-gradient(circle at 50% 50%, ${accentColor} 1px, transparent 1px)`,
+    backgroundSize: '8px 8px',
+  };
+};
+
+export const generateHexPattern = (accentColor: string): React.CSSProperties => {
+  const encodedColor = encodeURIComponent(accentColor);
+  return {
+    backgroundImage: `url("data:image/svg+xml,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cpolygon points='10,2 17,6 17,14 10,18 3,14 3,6' fill='${encodedColor}' opacity='0.15'/%3E%3C/svg%3E")`,
+    backgroundSize: '20px 20px',
+  };
+};
+
+export const generateWavePattern = (accentColor: string): React.CSSProperties => {
+  const encodedColor = encodeURIComponent(accentColor);
+  return {
+    backgroundImage: `url("data:image/svg+xml,%3Csvg width='20' height='10' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0,5 Q5,0 10,5 T20,5' stroke='${encodedColor}' stroke-width='1' fill='none' opacity='0.2'/%3E%3C/svg%3E")`,
+    backgroundSize: '20px 10px',
+  };
+};
+
+export const generateTrianglePattern = (accentColor: string): React.CSSProperties => {
+  return {
+    backgroundImage: `linear-gradient(45deg, transparent 40%, ${accentColor} 40%, ${accentColor} 60%, transparent 60%)`,
+    backgroundSize: '8px 8px',
+  };
+};
+
+export const generateCrossPattern = (accentColor: string): React.CSSProperties => {
+  return {
+    backgroundImage: `
+      linear-gradient(90deg, transparent 40%, ${accentColor} 40%, ${accentColor} 60%, transparent 60%),
+      linear-gradient(0deg, transparent 40%, ${accentColor} 40%, ${accentColor} 60%, transparent 60%)
+    `,
+    backgroundSize: '8px 8px',
+  };
+};
+
+export const generateTexturePattern = (accentColor: string): React.CSSProperties => {
+  return {
+    backgroundImage: `radial-gradient(circle at 50% 50%, ${accentColor} 1px, transparent 1px), radial-gradient(circle at 75% 75%, ${accentColor} 1px, transparent 1px)`,
+    backgroundSize: '4px 4px',
+  };
+};
+
+export const getBackgroundPattern = (patternType: BackgroundPatternType, accentColor: string): React.CSSProperties => {
+  switch (patternType) {
+    case 'squares':
+      return generateBackgroundPattern(accentColor);
+    case 'simple-squares':
+      return generateSimpleBackgroundPattern(accentColor);
+    case 'stripes':
+      return generateStripedPattern(accentColor);
+    case 'dots':
+      return generateDotPattern(accentColor);
+    case 'hexagon':
+      return generateHexPattern(accentColor);
+    case 'waves':
+      return generateWavePattern(accentColor);
+    case 'triangles':
+      return generateTrianglePattern(accentColor);
+    case 'cross':
+      return generateCrossPattern(accentColor);
+    case 'texture':
+      return generateTexturePattern(accentColor);
+    case 'none':
+    default:
+      return {};
+  }
 };
 
 export const getSizeClasses = (size: ComponentSize, type: 'depthChart' | 'attribute' | 'positionSlot') => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,15 @@ export default {
         25: 'repeat(25, minmax(0, 1fr))',
         20: 'repeat(20, minmax(0, 1fr))',
         16: 'repeat(16, minmax(0, 1fr))',
+        14: 'repeat(14, minmax(0, 1fr))',
+      },
+      gridTemplateRows: {
+        42: 'repeat(42, minmax(0, 1fr))',
+        25: 'repeat(25, minmax(0, 1fr))',
+        20: 'repeat(20, minmax(0, 1fr))',
+        16: 'repeat(16, minmax(0, 1fr))',
+        14: 'repeat(14, minmax(0, 1fr))',
+        12: 'repeat(12, minmax(0, 1fr))',
       },
     }
   },


### PR DESCRIPTION
This PR relates to the introduction of different formations for offense and defense on FormationView. The component has been re-factored to use config driven logic and rendering based on the teams selected offensive and defensive schemes.

- This is tied to the teams selected schemes. So if you have a Pistol offense, you will see visual representations of the five formations associated with Pistol, aligned with your current saved depth chart.
- This is also the case for Defensive scheme and the formations you will see.
- Leverages CSS Grid in regards to player placement. This is flexible, and highly customisable, should formations need to be added or tweaked in the future.
- Main logic for this is found within FormationViewHelper.tsx
- Re-usable constants used throughout the rendering logic

<img width="2547" height="1422" alt="image" src="https://github.com/user-attachments/assets/68b71e5b-ccf9-4a2b-ab6c-dca8109bcfad" />
<img width="2556" height="1420" alt="image" src="https://github.com/user-attachments/assets/4d9a4c13-f1d4-42e8-9515-3c8f1b540e57" />
<img width="2541" height="1423" alt="image" src="https://github.com/user-attachments/assets/3e6665e5-de5c-4623-b2fe-4c48ecc18060" />
<img width="2548" height="1422" alt="image" src="https://github.com/user-attachments/assets/b0f9dba6-58ac-4016-9117-172f8678aa49" />
