### PR TITLE
Add potential grade to NFL player modal

### DIFF
--- a/src/components/Common/Modals.tsx
+++ b/src/components/Common/Modals.tsx
@@ -952,10 +952,10 @@ console.log(contract)
       </div>
       <div className="flex flex-col">
         <Text variant="body" classes="mb-1 whitespace-nowrap font-semibold">
-          College
+          Potential
         </Text>
         <Text variant="small" classes="whitespace-nowrap">
-          {cfbTeam?.TeamAbbr}
+          {player.PotentialGrade}
         </Text>
       </div>
       <div className="flex flex-col items-center">
@@ -976,6 +976,9 @@ console.log(contract)
             </Text>
           </>
         )}
+        {cfbTeam && <Text variant="xs" classes="whitespace-nowrap text-small">
+          from {cfbTeam?.TeamAbbr}
+        </Text>}
       </div>
       {contract && (
         <>


### PR DESCRIPTION
I think potential value is worth putting in the player modal for NFL players, helps with screenshots in the Discord trade forum and such. I condensed "College" and "Drafted" to preserve the layout balance.
OLD:
Drafted -
<img width="547" height="697" alt="image" src="https://github.com/user-attachments/assets/3ce9dfec-eb2d-4940-b6f0-2cf1e492a68a" />
UDFA - 
<img width="553" height="636" alt="image" src="https://github.com/user-attachments/assets/5fb5cadb-07ed-4784-a59c-48fccccba151" />

NEW:
Drafted - 
<img width="555" height="694" alt="image" src="https://github.com/user-attachments/assets/aca874a3-acc7-4f78-9235-260d1ab26d35" />
UDFA -
<img width="558" height="642" alt="image" src="https://github.com/user-attachments/assets/206fa4f7-b409-40a1-9720-ff4084926a3e" />
