### PR TITLE
Fix sorting for Years Left column

### DIFF
--- a/src/_design/Table.tsx
+++ b/src/_design/Table.tsx
@@ -94,7 +94,8 @@ export const Table = <T,>({
         key.includes("Y2") ||
         key.includes("Y3") ||
         key.includes("Y4") ||
-        key.includes("Y5")
+        key.includes("Y5") ||
+        key.includes("ContractLength")
       ) {
         if (a.Contract[key] > b.Contract[key]) return order === "asc" ? -1 : 1;
         if (a.Contract[key] < b.Contract[key]) return order === "asc" ? 1 : -1;


### PR DESCRIPTION
Sorting for the "Years Left" column on roster pages was non-functional due to a missing check on the "ContractLength" key, so it failed to look in the player's Contract object for the years remaining when sorting. This fixes that.