### PR TITLE
Fix sorting by year on college player tables

### DIFF
--- a/src/_design/Table.tsx
+++ b/src/_design/Table.tsx
@@ -131,6 +131,14 @@ export const Table = <T,>({
         if (a.Contract[key] < b.Contract[key]) return order === "asc" ? 1 : -1;
       }
 
+      if ((league?.includes("SimC") || league === undefined) && key === "Experience") { // College league player year, league is undefined on simcfb for some reason
+        if (a["Year"] > b["Year"]) return order === "asc" ? 1 : -1;
+        if (a["Year"] < b["Year"]) return order === "asc" ? -1 : 1;
+        if (!a["IsRedshirt"] && b["IsRedshirt"]) return order === "asc" ? 1 : -1;
+        if (a["IsRedshirt"] && !b["IsRedshirt"]) return order === "asc" ? -1 : 1;
+        return 0;
+      }
+
       if (key.includes("Grade")) {
         // Clean and normalize the grade values
         let aGrade = (a[key] ?? "").toString().trim();


### PR DESCRIPTION
Sorting by year on college player tables has been broken since v2 interface launch. This PR should fix that. I can only confirm SimCFB at the moment, as I don't participate in other leagues, but I believe it should work based on other sorting code in this section.

Also, when viewing the roster table in SimCFB, `league` comes back as undefined, for whatever reason, despite being `SimNFL` when looking at pro rosters. Not sure why that is.

Local validation:
Descending:
<img width="1905" height="768" alt="image" src="https://github.com/user-attachments/assets/b30aa72a-1bbc-4d68-b67a-3f0d0e5b9814" />

Ascending:
<img width="1910" height="788" alt="image" src="https://github.com/user-attachments/assets/cd64960f-15a9-4264-868c-579275728136" />
