### PR TITLE
Add Guam to close-to-home map and null check to state matcher check

### DIFF
--- a/src/_helper/recruitingHelper.tsx
+++ b/src/_helper/recruitingHelper.tsx
@@ -289,7 +289,8 @@ export const ValidateCloseToHome = (croot: any, abbr: any) => {
   }
 
   const closeToHomeSchools = StateMatcherMap[crootState];
-  if (closeToHomeSchools.length <= 0) {
+  if (!closeToHomeSchools || closeToHomeSchools.length <= 0) {
+    console.log("Warning: no close-to-home schools found for croot:", String(croot.FirstName) + " " + String(croot.LastName), "State: ", crootState);
     return false;
   }
 

--- a/src/_matchers/stateMatcher.json
+++ b/src/_matchers/stateMatcher.json
@@ -80,6 +80,7 @@
         "WOFF",
         "CIT"
     ],
+    "GM": ["UOG"],
     "HI": ["HAWI"],
     "ID": [
         "BOIS",

--- a/src/_matchers/stateMatcher.json
+++ b/src/_matchers/stateMatcher.json
@@ -28,6 +28,7 @@
         "MOST",
         "MSVU"
     ],
+    "AS": ["SAMO"],
     "AZ": ["ZONA", "AZST", "UNLV", "NAU"],
     "CA(N)": [
         "CAL",


### PR DESCRIPTION
If a croot has a state that is not in the close-to-home mapping check, the recruiting page crashes when attempting to render that recruit, which happened in the case of Tane Babauta here.
<img width="553" height="414" alt="image" src="https://github.com/user-attachments/assets/6864f5ad-b955-4ea4-8518-82bd1292b55b" />

I've added an existence check to the `closeToHomeSchools.length` and a log warning if a recruit has no close-to-home schools. I've also added Guam to the `StateMatcher` table for determining close-to-home schools. I know we have American Samoa now as well, though I don't know if we could see any recruits generate there any time soon. I _could_ add them to the table as well, but I don't know what their state abbreviation is in the sim.