### PR TITLE
Fix completed games check for redshirting counting spring games

### DIFF
--- a/src/context/SimFBAContext.tsx
+++ b/src/context/SimFBAContext.tsx
@@ -1369,7 +1369,7 @@ export const SimFBAProvider: React.FC<SimFBAProviderProps> = ({ children }) => {
       const gamesCompleted = collegeTeamsGames.filter(
         (game) =>
           (game.HomeTeamID === teamID || game.AwayTeamID === teamID) &&
-          game.GameComplete,
+          game.GameComplete && !game.IsSpringGame,
       ).length;
 
       if (gamesCompleted > 4) {


### PR DESCRIPTION
The check to block redshirting on players with four or more games completed is counting spring games towards the count. Adding a condition to the check to fix that